### PR TITLE
Iteration 1: evidence layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,12 +227,10 @@ deployment_trigger.txt
 *_deploy.sh
 deploy-*.sh
 
-# Documentation files (keep only main README.md)
+# Documentation files
 DEVELOPMENT.md
 QUICKSTART.md
-ARCHITECTURE.md
-docs/
-!docs/README.md
+docs/screenshots/
 
 # Test documents and PDFs
 tests/downloaded_documents/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # CivicSpark AI
 
-Civic engagement platform for Tulsa residents. AI-powered tools for city government interaction, meeting notifications, and community organizing.
+Civic engagement platform for Tulsa residents: a searchable evidence layer
+over city government documents, with AI assistance on top — meeting explorer,
+grounded Q&A, topic notifications, representative lookup, and organizing
+tools.
 
-**Archived.** This repository is the initial proof-of-concept. The project continues in active development with a new architecture. The demo was built in consultation with the Tulsa City Auditor's Office and local community organizations.
-
-**Live demo:** [https://d1s9nkkr0t3pmn.cloudfront.net](https://d1s9nkkr0t3pmn.cloudfront.net)
+Built in consultation with the Tulsa City Auditor's Office and local
+community organizations. Design notes and iteration plan:
+[kaizencode.art/garden/citycamp-ai](https://kaizencode.art/garden/citycamp-ai/)
 
 ![](homepage.png)
 
@@ -12,66 +15,52 @@ Civic engagement platform for Tulsa residents. AI-powered tools for city governm
 
 ## Features
 
-- **AI Chatbot** — RAG-enhanced responses using city budgets, legislation, and policies
-- **Meeting Notifications** — Topic-based subscriptions (housing, transportation, etc.) via SMS and email
-- **Meeting Analytics** — AI categorization of 42+ civic topics, searchable minutes
-- **Representative Lookup** — District-based lookup with AI-powered email generation
-- **Campaigns** — Campaign tracking and neighborhood organizing tools
-
----
-
-## RAG System
-
-The chatbot uses Retrieval-Augmented Generation (RAG) to search and cite actual city documents instead of generic responses.
-
-**Pipeline:** Document upload → Text extraction → Chunking (512 tokens, 50 overlap) → Embeddings (OpenAI text-embedding-3-small) → Vector store (ChromaDB / FAISS) → Semantic search → Context injection at query time
-
-**Components:** ChromaDB (dev) / FAISS (prod), PostgreSQL for metadata, FastAPI for upload/search
-
-**Document types:** Budgets, legislation, meeting minutes, reports, policies
-
-**Setup:** `pip install -r backend/requirements.txt` then `cd backend && python -m alembic upgrade head`. See [docs/RAG_SYSTEM_README.md](docs/RAG_SYSTEM_README.md).
+- **Meeting Explorer** — searchable agendas and minutes, AI categorization
+  across 42+ civic topics
+- **Grounded Q&A** — chatbot answers cite actual city documents (budgets,
+  legislation, policies) with source links and retrieval dates; it refuses
+  rather than invents figures
+- **Topic Watch** — subscriptions (housing, transportation, …) via SMS and
+  email
+- **Representative Lookup** — district lookup by address, with AI-drafted
+  constituent email that the user reviews and sends themself — never
+  auto-sent
+- **Campaigns** — campaign tracking and neighborhood organizing tools
 
 ---
 
 ## Architecture
 
+One database, one API, one static frontend. Runs free at small scale.
+
+```
+Vercel (React SPA) ─ /api/* ─► Render (FastAPI) ─► Postgres (pgvector)
+                                                     ├─ relational data
+                                                     ├─ RAG vector index
+                                                     └─ full-text search
+```
+
 | Layer | Technology |
 |-------|------------|
-| Frontend | React 18, TypeScript, Vite, Tailwind |
-| Backend | FastAPI, Python 3.11 |
-| Database | PostgreSQL, Redis |
-| AI | OpenAI GPT-4, RAG (ChromaDB/FAISS) |
-| Infrastructure | AWS (ECS, RDS, S3, CloudFront) |
+| Frontend | React 18, TypeScript, Vite, Tailwind (Vercel) |
+| Backend | FastAPI, Python 3.11 (Render, Docker) |
+| Database | PostgreSQL + pgvector — the only stateful service |
+| LLM | Open-source models via any OpenAI-compatible API — Llama 3.3 70B on Groq by default |
+| Embeddings | Jina v3 by default (configurable; numpy fallback needs no extension) |
 
-```
-CloudFront → React SPA (S3) + FastAPI (ECS)
-                    │
-                    ├── PostgreSQL (RDS)
-                    ├── Redis (ElastiCache)
-                    ├── OpenAI API
-                    └── RAG Vector Store (ChromaDB/FAISS)
-```
+Key properties:
 
----
+- **The index survives deploys** — vectors live on document chunks in
+  Postgres, not on ephemeral disk
+- **Search before chat** — hybrid retrieval (FTS ∪ dense vectors, rank
+  fusion) works even with no LLM configured
+- **Provenance everywhere** — every document records source hash and
+  retrieval time; the API reports how fresh the index is
+- **Provider-agnostic AI** — swap Groq for OpenRouter, Together, or local
+  Ollama by env var; no OpenAI dependency
 
-## Project Structure
-
-```
-backend/          # FastAPI app
-  app/api/v1/     # REST endpoints
-  app/models/     # SQLAlchemy models
-  app/services/   # Chatbot, vector, document processing
-  app/scrapers/   # Tulsa city council data
-
-frontend/         # React + TypeScript
-  src/pages/      # Route components
-  src/components/ # Shared UI
-
-aws/              # Terraform, deployment scripts
-docs/             # Documentation
-tests/            # Backend (pytest), frontend (Jest)
-```
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full design and
+roadmap.
 
 ---
 
@@ -81,13 +70,15 @@ tests/            # Backend (pytest), frontend (Jest)
 git clone https://github.com/kaizengrowth/CivicSpark_AI.git
 cd CivicSpark_AI
 
-# Backend
+# Everything at once (pgvector Postgres + API + frontend):
+docker compose up
+
+# Or natively:
 cd backend && python -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
-cp env.example .env
+pip install -r requirements-dev.txt
+cp env.example .env   # add your LLM_API_KEY (Groq) + EMBEDDING_API_KEY (Jina)
 python -m app.main
 
-# Frontend (new terminal)
 cd frontend && npm install && npm run dev
 ```
 
@@ -95,7 +86,17 @@ cd frontend && npm install && npm run dev
 - API: http://localhost:8000
 - API docs: http://localhost:8000/docs
 
-**Required env vars:** `DATABASE_URL`, `REDIS_URL`, `OPENAI_API_KEY`, `SECRET_KEY`
+**Required env vars:** `DATABASE_URL`, `SECRET_KEY`, `LLM_API_KEY`
+(everything else is optional — features degrade gracefully).
+
+---
+
+## Deployment
+
+| Target | How |
+|--------|-----|
+| Render (API + Postgres) | Connect the repo as a Blueprint — [render.yaml](render.yaml) |
+| Vercel (frontend) | Import the repo — [vercel.json](vercel.json) proxies `/api/*` to Render |
 
 ---
 
@@ -103,8 +104,8 @@ cd frontend && npm install && npm run dev
 
 | Document | Description |
 |----------|-------------|
-| [RAG System](docs/RAG_SYSTEM_README.md) | Document processing and vector search |
-| [AWS Deployment](docs/aws-deployment-guide.md) | Production infrastructure |
+| [Architecture](docs/ARCHITECTURE.md) | System design, evidence layer, roadmap |
+| [Design sketch](https://kaizencode.art/garden/citycamp-ai/) | Product direction, peer systems, failure modes |
 
 ---
 

--- a/backend/alembic/versions/006_add_document_provenance.py
+++ b/backend/alembic/versions/006_add_document_provenance.py
@@ -1,0 +1,50 @@
+"""Add provenance columns to documents
+
+Every indexed document records the sha256 of its source file and when it
+was retrieved, so the UI can show "index as of ..." and re-ingestion can
+skip unchanged sources.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "006"
+down_revision = "005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    conn.execute(
+        text("ALTER TABLE documents ADD COLUMN IF NOT EXISTS content_hash VARCHAR(64)")
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE documents "
+            "ADD COLUMN IF NOT EXISTS retrieved_at TIMESTAMP WITH TIME ZONE"
+        )
+    )
+    conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_documents_content_hash "
+            "ON documents (content_hash)"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    conn.execute(text("DROP INDEX IF EXISTS ix_documents_content_hash"))
+    conn.execute(text("ALTER TABLE documents DROP COLUMN IF EXISTS retrieved_at"))
+    conn.execute(text("ALTER TABLE documents DROP COLUMN IF EXISTS content_hash"))

--- a/backend/alembic/versions/007_add_fts_index.py
+++ b/backend/alembic/versions/007_add_fts_index.py
@@ -1,0 +1,46 @@
+"""Add full-text search index for hybrid retrieval
+
+The keyword half of hybrid search uses Postgres FTS over chunk content.
+A GIN index keeps it fast as the corpus grows; search works (sequential
+scan) without it, so failures here are non-fatal.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+import logging
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "007"
+down_revision = "006"
+branch_labels = None
+depends_on = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    try:
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS ix_document_chunks_fts "
+                "ON document_chunks USING gin (to_tsvector('english', content))"
+            )
+        )
+    except Exception as e:
+        logger.warning(f"Could not create FTS index (search still works): {e}")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    conn.execute(text("DROP INDEX IF EXISTS ix_document_chunks_fts"))

--- a/backend/alembic/versions/008_add_legislative_identity_keys.py
+++ b/backend/alembic/versions/008_add_legislative_identity_keys.py
@@ -1,0 +1,79 @@
+"""Add legislative identity keys to documents and chunks
+
+"What did Council decide on X?" is an identity query. Chunks now carry
+their meeting/agenda-item lineage so retrieval can answer with the item,
+not an anonymous token window.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "008"
+down_revision = "007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    conn.execute(
+        text("ALTER TABLE documents ADD COLUMN IF NOT EXISTS meeting_id INTEGER")
+    )
+    conn.execute(
+        text("ALTER TABLE document_chunks ADD COLUMN IF NOT EXISTS meeting_id INTEGER")
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE document_chunks "
+            "ADD COLUMN IF NOT EXISTS agenda_item_id INTEGER"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE document_chunks "
+            "ADD COLUMN IF NOT EXISTS item_number VARCHAR(50)"
+        )
+    )
+    conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_documents_meeting_id "
+            "ON documents (meeting_id)"
+        )
+    )
+    conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_document_chunks_meeting_id "
+            "ON document_chunks (meeting_id)"
+        )
+    )
+    conn.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_document_chunks_agenda_item_id "
+            "ON document_chunks (agenda_item_id)"
+        )
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name != "postgresql":
+        return
+    conn.execute(text("DROP INDEX IF EXISTS ix_document_chunks_agenda_item_id"))
+    conn.execute(text("DROP INDEX IF EXISTS ix_document_chunks_meeting_id"))
+    conn.execute(text("DROP INDEX IF EXISTS ix_documents_meeting_id"))
+    conn.execute(
+        text("ALTER TABLE document_chunks DROP COLUMN IF EXISTS item_number")
+    )
+    conn.execute(
+        text("ALTER TABLE document_chunks DROP COLUMN IF EXISTS agenda_item_id")
+    )
+    conn.execute(text("ALTER TABLE document_chunks DROP COLUMN IF EXISTS meeting_id"))
+    conn.execute(text("ALTER TABLE documents DROP COLUMN IF EXISTS meeting_id"))

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -160,6 +160,9 @@ async def upload_document(
     document_date: Optional[str] = Form(None),  # ISO format date
     effective_date: Optional[str] = Form(None),  # ISO format date
     source_url: Optional[str] = Form(None),
+    meeting_id: Optional[int] = Form(
+        None, description="Meeting this agenda/minutes document belongs to"
+    ),
     is_public: bool = Form(True),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_active_user),
@@ -219,6 +222,7 @@ async def upload_document(
             "document_date": doc_date,
             "effective_date": eff_date,
             "source_url": source_url or "",
+            "meeting_id": meeting_id,
             "is_public": is_public,
             "uploaded_by": current_user.id,
         }

--- a/backend/app/api/v1/endpoints/documents.py
+++ b/backend/app/api/v1/endpoints/documents.py
@@ -20,7 +20,7 @@ from app.services.document_processing_service import DocumentProcessingService
 from app.services.vector_service import VectorService
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, func, or_
 from sqlalchemy.orm import Session
 
 router = APIRouter()
@@ -337,7 +337,7 @@ async def get_document_stats(db: Session = Depends(get_db)):
 
     # Count by type
     type_counts = (
-        db.query(Document.document_type, db.func.count(Document.id))
+        db.query(Document.document_type, func.count(Document.id))
         .filter(Document.is_public == True)
         .group_by(Document.document_type)
         .all()
@@ -345,15 +345,24 @@ async def get_document_stats(db: Session = Depends(get_db)):
 
     # Count by category
     category_counts = (
-        db.query(Document.category, db.func.count(Document.id))
+        db.query(Document.category, func.count(Document.id))
         .filter(and_(Document.is_public == True, Document.category != ""))
         .group_by(Document.category)
         .all()
     )
 
+    # "Index as of": the newest retrieval timestamp in the public corpus,
+    # so the UI can show how fresh answers can possibly be.
+    index_as_of = (
+        db.query(func.max(Document.retrieved_at))
+        .filter(Document.is_public == True)
+        .scalar()
+    )
+
     return {
         "total_documents": total_docs,
         "processed_documents": processed_docs,
+        "index_as_of": index_as_of.isoformat() if index_as_of else None,
         "processing_rate": (
             round(processed_docs / total_docs * 100, 1) if total_docs > 0 else 0
         ),

--- a/backend/app/api/v1/endpoints/meetings.py
+++ b/backend/app/api/v1/endpoints/meetings.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 
 import httpx
 from app.core.database import get_db
+from app.models.document import DocumentChunk
 from app.models.meeting import AgendaItem, Meeting, MeetingCategory
 from app.schemas.base import PaginationParams, StandardListResponse
 from app.schemas.meeting import (
@@ -249,6 +250,68 @@ async def get_meeting_detail(meeting_id: int, db: Session = Depends(get_db)):
         categories=categories,
         pdf_url=f"/api/v1/meetings/{meeting_id}/pdf" if meeting.minutes_url else None,
     )
+
+
+@router.get("/{meeting_id}/items", response_model=List[AgendaItemResponse])
+async def list_agenda_items(meeting_id: int, db: Session = Depends(get_db)):
+    """Canonical agenda-item list for a meeting (deep-linkable)"""
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+    if not meeting:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    return (
+        db.query(AgendaItem)
+        .filter(AgendaItem.meeting_id == meeting_id)
+        .order_by(AgendaItem.id)
+        .all()
+    )
+
+
+@router.get("/{meeting_id}/items/{item_id}")
+async def get_agenda_item(
+    meeting_id: int, item_id: int, db: Session = Depends(get_db)
+):
+    """Canonical record for one agenda item: the deep-link target.
+
+    Returns the structured item plus any indexed document excerpts linked
+    to it, so a journalist can cite the item without touching the chatbot.
+    """
+    item = (
+        db.query(AgendaItem)
+        .filter(AgendaItem.id == item_id, AgendaItem.meeting_id == meeting_id)
+        .first()
+    )
+    if not item:
+        raise HTTPException(status_code=404, detail="Agenda item not found")
+
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+
+    chunks = (
+        db.query(DocumentChunk)
+        .filter(DocumentChunk.agenda_item_id == item_id)
+        .order_by(DocumentChunk.chunk_index)
+        .limit(10)
+        .all()
+    )
+
+    return {
+        "item": AgendaItemResponse.model_validate(item),
+        "meeting": {
+            "id": meeting.id,
+            "title": meeting.title,
+            "meeting_date": meeting.meeting_date,
+        },
+        "excerpts": [
+            {
+                "document_id": chunk.document_id,
+                "chunk_index": chunk.chunk_index,
+                "section_title": chunk.section_title,
+                "content": chunk.content,
+            }
+            for chunk in chunks
+        ],
+        "deep_link": f"/meetings?meeting={meeting_id}",
+    }
 
 
 @router.get("/{meeting_id}/pdf")

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -53,6 +53,21 @@ def ensure_pgvector() -> bool:
     if engine.dialect.name != "postgresql":
         return False
 
+    # Full-text search index for the keyword half of hybrid retrieval.
+    # Independent of pgvector: keyword search must work even when no
+    # embedding provider is configured.
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_document_chunks_fts "
+                    "ON document_chunks "
+                    "USING gin (to_tsvector('english', content))"
+                )
+            )
+    except Exception as e:
+        logger.warning(f"Could not create FTS index (search still works): {e}")
+
     # Dimension follows the configured embedding provider. Switching
     # providers with a different dimension requires dropping the embedding
     # column and re-embedding the corpus.

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -34,6 +34,9 @@ class Document(Base):
     # Provenance: never index without knowing what was fetched and when.
     content_hash = Column(String(64), index=True)  # sha256 of the source file
     retrieved_at = Column(DateTime(timezone=True))  # when the source was fetched
+
+    # Legislative identity: agendas/minutes belong to a specific meeting.
+    meeting_id = Column(Integer, ForeignKey("meetings.id"), nullable=True, index=True)
     file_path = Column(String(1000))  # Local file storage path
     file_name = Column(String(500))
     file_size = Column(Integer)  # Size in bytes
@@ -109,6 +112,15 @@ class DocumentChunk(Base):
     # Chunk content
     content = Column(Text, nullable=False)  # The actual text chunk
     chunk_index = Column(Integer, nullable=False)  # Order within document
+
+    # Legislative identity keys: "what did Council decide on X?" is an
+    # identity query, so chunks keep their meeting/agenda-item lineage
+    # instead of being anonymous token windows.
+    meeting_id = Column(Integer, ForeignKey("meetings.id"), nullable=True, index=True)
+    agenda_item_id = Column(
+        Integer, ForeignKey("agenda_items.id"), nullable=True, index=True
+    )
+    item_number = Column(String(50))  # e.g. "2.a" — kept even when unmatched
 
     # Chunk metadata
     start_page = Column(Integer)  # Starting page number

--- a/backend/app/models/document.py
+++ b/backend/app/models/document.py
@@ -30,6 +30,10 @@ class Document(Base):
     )  # budget, legislation, policy, meeting_minutes, etc.
     category = Column(String(100), index=True)  # transportation, housing, finance, etc.
     source_url = Column(String(1000))  # Original document URL
+
+    # Provenance: never index without knowing what was fetched and when.
+    content_hash = Column(String(64), index=True)  # sha256 of the source file
+    retrieved_at = Column(DateTime(timezone=True))  # when the source was fetched
     file_path = Column(String(1000))  # Local file storage path
     file_name = Column(String(500))
     file_size = Column(Integer)  # Size in bytes

--- a/backend/app/services/agenda_parser.py
+++ b/backend/app/services/agenda_parser.py
@@ -1,0 +1,119 @@
+"""Structure-aware parsing of council agendas and minutes.
+
+Fixed-size token windows lose legislative identity — "what did Council
+decide on item 2.a?" cannot be answered from anonymous chunk soup. This
+parser recovers the agenda tree from extracted text so documents can be
+chunked by agenda item, with the item number and title kept as metadata
+on every chunk.
+
+The format targeted is the common US council agenda/minutes shape
+(Granicus/Legistar exports, which Tulsa's TGOV uses): numbered items
+("1.", "2.a.", "3.B)"), optionally grouped under ALL-CAPS section
+headings ("CONSENT AGENDA", "PUBLIC HEARINGS"). Parsing is best-effort:
+callers fall back to fixed-window chunking when fewer than two items are
+found.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+# Numbered item headers: "1.", "12.", "1.a.", "2.B.", "3.a)", "4)" —
+# anchored at line start, followed by the item title text.
+ITEM_HEADER_RE = re.compile(
+    r"^\s{0,8}(?P<number>\d{1,3}(?:\.[A-Za-z0-9]{1,3})*[.)])\s+(?P<title>\S.*)$"
+)
+
+# Section headings: a line that is (almost) all caps, reasonably short,
+# and not just a number — e.g. "CONSENT AGENDA", "PUBLIC HEARINGS".
+SECTION_HEADING_RE = re.compile(r"^\s{0,8}(?P<heading>[A-Z][A-Z0-9\s&/,'\-\.]{5,80})$")
+
+# Lines that look like page furniture rather than content.
+PAGE_NOISE_RE = re.compile(r"^\s*(Page \d+( of \d+)?|-+|_+|\d+)\s*$", re.IGNORECASE)
+
+
+@dataclass
+class ParsedAgendaItem:
+    """One agenda item recovered from document text"""
+
+    item_number: Optional[str]  # normalized, e.g. "2.a" (None for sections)
+    title: str
+    text: str = ""
+    section: Optional[str] = None  # enclosing section heading, if any
+    order: int = 0
+    lines: List[str] = field(default_factory=list)
+
+
+def normalize_item_number(raw: str) -> str:
+    """Normalize '2.A.' / '2.a)' → '2.a' for stable matching"""
+    return raw.strip().rstrip(".)").lower()
+
+
+def parse_agenda_items(text: str) -> List[ParsedAgendaItem]:
+    """Recover the agenda-item list from extracted agenda/minutes text.
+
+    Returns an empty list when no plausible item structure is found, so
+    callers can fall back to fixed-window chunking.
+    """
+    items: List[ParsedAgendaItem] = []
+    current: Optional[ParsedAgendaItem] = None
+    current_section: Optional[str] = None
+    preamble_lines = 0
+
+    for line in text.splitlines():
+        stripped = line.rstrip()
+        if not stripped.strip() or PAGE_NOISE_RE.match(stripped):
+            continue
+
+        header = ITEM_HEADER_RE.match(stripped)
+        if header:
+            if current is not None:
+                current.text = "\n".join(current.lines).strip()
+                items.append(current)
+            current = ParsedAgendaItem(
+                item_number=normalize_item_number(header.group("number")),
+                title=header.group("title").strip(),
+                section=current_section,
+                order=len(items),
+            )
+            continue
+
+        section = SECTION_HEADING_RE.match(stripped)
+        if section and _plausible_section(section.group("heading")):
+            # A section heading closes the current item and scopes the next.
+            if current is not None:
+                current.text = "\n".join(current.lines).strip()
+                items.append(current)
+                current = None
+            current_section = section.group("heading").strip()
+            continue
+
+        if current is not None:
+            current.lines.append(stripped.strip())
+        else:
+            preamble_lines += 1
+
+    if current is not None:
+        current.text = "\n".join(current.lines).strip()
+        items.append(current)
+
+    numbered = [item for item in items if item.item_number]
+    if len(numbered) < 2:
+        return []
+
+    return items
+
+
+def _plausible_section(heading: str) -> bool:
+    """Filter ALL-CAPS lines that are shouting text rather than headings"""
+    words = heading.split()
+    return 1 <= len(words) <= 8 and any(ch.isalpha() for ch in heading)
+
+
+def item_chunk_title(item: ParsedAgendaItem) -> str:
+    """Human-readable chunk section title, e.g. 'Item 2.a: Rezoning ...'"""
+    prefix = f"Item {item.item_number}: " if item.item_number else ""
+    title = f"{prefix}{item.title}"
+    if item.section:
+        title = f"{item.section} — {title}"
+    return title[:500]

--- a/backend/app/services/chatbot_service.py
+++ b/backend/app/services/chatbot_service.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 from app.core.config import Settings
 from app.core.llm import get_chat_client
 from app.models.campaign import Campaign
+from app.models.document import Document
 from app.models.meeting import Meeting
 from app.services.research_service import ResearchService
 from app.services.vector_service import VectorService
@@ -39,6 +40,7 @@ class ChatbotService:
 You have extensive knowledge about Tulsa government, civic processes, city services, local politics, and community engagement opportunities. Feel free to provide detailed, conversational responses that help people understand and get involved in their local government.
 
 RESPONSE APPROACH:
+- **Never invent specific figures, vote outcomes, or ordinance text.** For dollar amounts, budget lines, or what the law says, use document search and cite the source; if the corpus doesn't contain the answer, say so plainly and point to the official source (cityoftulsa.org, tulsacouncil.org) instead of guessing
 - Be conversational, helpful, and encouraging
 - Provide as much detail as needed to fully answer questions
 - Use your knowledge to give comprehensive, nuanced responses
@@ -436,24 +438,58 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                 )
 
                 if results:
+                    # Resolve source documents so every excerpt carries a
+                    # citation: title, source link, and retrieval date.
+                    doc_ids = {
+                        result["metadata"]["document_id"]
+                        for result in results
+                        if result.get("metadata")
+                    }
+                    documents = (
+                        {
+                            doc.id: doc
+                            for doc in self.db.query(Document)
+                            .filter(Document.id.in_(doc_ids))
+                            .all()
+                        }
+                        if doc_ids
+                        else {}
+                    )
+
                     formatted_results = "**Relevant Tulsa Documents:**\n\n"
                     for i, result in enumerate(results, 1):
                         metadata = result.get("metadata", {})
                         content = result.get("content", "")
-                        similarity = result.get("similarity", 0)
+                        document = documents.get(metadata.get("document_id"))
 
-                        formatted_results += (
-                            f"**{i}. Document Excerpt** (relevance: {similarity:.2f})\n"
-                        )
+                        title = document.title if document else "Document excerpt"
+                        if document and document.source_url:
+                            formatted_results += f"**{i}. [{title}]({document.source_url})**\n"
+                        else:
+                            formatted_results += f"**{i}. {title}**\n"
+
+                        details = []
                         if metadata.get("document_type"):
-                            formatted_results += f"Type: {metadata['document_type']}\n"
+                            details.append(metadata["document_type"])
                         if metadata.get("category"):
-                            formatted_results += f"Category: {metadata['category']}\n"
-                        formatted_results += f"Content: {content[:300]}...\n\n"
+                            details.append(metadata["category"])
+                        if document and document.retrieved_at:
+                            details.append(
+                                f"retrieved {document.retrieved_at.strftime('%Y-%m-%d')}"
+                            )
+                        if details:
+                            formatted_results += f"*{' · '.join(details)}*\n"
+
+                        formatted_results += f"> {content[:300]}...\n\n"
 
                     return formatted_results
                 else:
-                    return "No relevant documents found in the database."
+                    return (
+                        "No matching documents in the indexed corpus. For "
+                        "authoritative information, check "
+                        "[cityoftulsa.org](https://www.cityoftulsa.org) or "
+                        "[tulsacouncil.org](https://www.tulsacouncil.org)."
+                    )
 
             elif function_name == "retrieve_document":
                 url = arguments.get("url", "")

--- a/backend/app/services/chatbot_service.py
+++ b/backend/app/services/chatbot_service.py
@@ -469,7 +469,9 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                             formatted_results += f"**{i}. {title}**\n"
 
                         details = []
-                        if metadata.get("document_type"):
+                        if metadata.get("section_title"):
+                            details.append(metadata["section_title"])
+                        elif metadata.get("document_type"):
                             details.append(metadata["document_type"])
                         if metadata.get("category"):
                             details.append(metadata["category"])
@@ -479,6 +481,19 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                             )
                         if details:
                             formatted_results += f"*{' · '.join(details)}*\n"
+
+                        # Deep link to the meeting record when the chunk
+                        # carries legislative identity.
+                        if metadata.get("meeting_id"):
+                            item_ref = (
+                                f" (item {metadata['item_number']})"
+                                if metadata.get("item_number")
+                                else ""
+                            )
+                            formatted_results += (
+                                f"[View meeting record{item_ref}]"
+                                f"(/meetings?meeting={metadata['meeting_id']})\n"
+                            )
 
                         formatted_results += f"> {content[:300]}...\n\n"
 

--- a/backend/app/services/document_processing_service.py
+++ b/backend/app/services/document_processing_service.py
@@ -34,11 +34,20 @@ except ImportError:
 from app.core.config import Settings
 from app.core.llm import get_chat_client
 from app.models.document import Document, DocumentChunk
+from app.models.meeting import AgendaItem
+from app.services.agenda_parser import (
+    item_chunk_title,
+    normalize_item_number,
+    parse_agenda_items,
+)
 from app.services.vector_service import VectorService
 from docx import Document as DocxDocument
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+# Document types that carry agenda-item structure worth preserving.
+AGENDA_DOCUMENT_TYPES = {"agenda", "minutes", "meeting_minutes"}
 
 
 class DocumentProcessor:
@@ -47,9 +56,14 @@ class DocumentProcessor:
     def __init__(self, settings: Settings):
         self.settings = settings
         self.openai_client, self.chat_model = get_chat_client(settings)
-        self.encoding = (
-            tiktoken.get_encoding("cl100k_base") if TIKTOKEN_AVAILABLE else None
-        )  # GPT-4 encoding
+        # tiktoken fetches its vocabulary on first use; fall back to the
+        # chars/4 estimate when that isn't possible (offline dev, tests).
+        self.encoding = None
+        if TIKTOKEN_AVAILABLE:
+            try:
+                self.encoding = tiktoken.get_encoding("cl100k_base")
+            except Exception as e:
+                logger.warning(f"tiktoken unavailable, using char estimate: {e}")
 
     def detect_file_type(self, file_path: str) -> str:
         """Detect file MIME type"""
@@ -452,8 +466,10 @@ class DocumentProcessingService:
             stored_path = self._store_file(file_path)
 
             # Create document record
+            meeting_id = document_data.get("meeting_id")
             document = Document(
                 title=document_data.get("title", Path(file_path).stem),
+                meeting_id=meeting_id,
                 content=cleaned_text,
                 summary=summary,
                 document_type=document_data.get("document_type", "unknown"),
@@ -481,12 +497,29 @@ class DocumentProcessingService:
             self.db.commit()
             self.db.refresh(document)
 
-            # Chunk the text
-            chunks_data = self.processor.chunk_text(cleaned_text)
+            # Chunk the text: by agenda item when the document has that
+            # structure, fixed windows otherwise.
+            chunks_data = self._chunk_document(cleaned_text, document.document_type)
+
+            # Match parsed item numbers to structured AgendaItem rows so
+            # chunks carry real identity keys, not just labels.
+            item_id_by_number = {}
+            if meeting_id:
+                agenda_rows = (
+                    self.db.query(AgendaItem)
+                    .filter(AgendaItem.meeting_id == meeting_id)
+                    .all()
+                )
+                item_id_by_number = {
+                    normalize_item_number(row.item_number): row.id
+                    for row in agenda_rows
+                    if row.item_number
+                }
 
             # Create chunk records and prepare for vector store
             chunks_for_vector = []
             for chunk_data in chunks_data:
+                item_number = chunk_data.get("item_number")
                 chunk = DocumentChunk(
                     document_id=document.id,
                     content=chunk_data["content"],
@@ -494,6 +527,13 @@ class DocumentProcessingService:
                     word_count=chunk_data["word_count"],
                     start_char=chunk_data["start_char"],
                     end_char=chunk_data["end_char"],
+                    section_title=chunk_data.get("section_title"),
+                    section_type=chunk_data.get("section_type"),
+                    item_number=item_number,
+                    meeting_id=meeting_id,
+                    agenda_item_id=(
+                        item_id_by_number.get(item_number) if item_number else None
+                    ),
                 )
 
                 self.db.add(chunk)
@@ -538,6 +578,38 @@ class DocumentProcessingService:
                 self.db.commit()
 
             return None
+
+    def _chunk_document(self, cleaned_text: str, document_type: str) -> list:
+        """Chunk by agenda item when structure is present, else fixed windows"""
+        if (document_type or "").lower() in AGENDA_DOCUMENT_TYPES:
+            items = parse_agenda_items(cleaned_text)
+            if items:
+                logger.info(f"Parsed {len(items)} agenda items; chunking by item")
+                return self._chunk_by_items(items)
+            logger.info("No agenda structure found; falling back to fixed windows")
+        return self.processor.chunk_text(cleaned_text)
+
+    def _chunk_by_items(self, items: list) -> list:
+        """One or more chunks per agenda item, item metadata on every chunk"""
+        chunks = []
+        for item in items:
+            body = f"{item.title}\n\n{item.text}".strip()
+            sub_chunks = self.processor.chunk_text(body) or [
+                {
+                    "content": body,
+                    "chunk_index": 0,
+                    "word_count": len(body.split()),
+                    "start_char": 0,
+                    "end_char": 0,
+                }
+            ]
+            for sub in sub_chunks:
+                sub["chunk_index"] = len(chunks)
+                sub["section_title"] = item_chunk_title(item)
+                sub["section_type"] = "agenda_item"
+                sub["item_number"] = item.item_number
+                chunks.append(sub)
+        return chunks
 
     def _store_file(self, file_path: str) -> str:
         """Copy an uploaded file into the configured storage directory"""

--- a/backend/app/services/vector_service.py
+++ b/backend/app/services/vector_service.py
@@ -224,6 +224,7 @@ class VectorService:
             text(
                 "SELECT dc.document_id, dc.chunk_index, dc.content, "
                 "d.document_type, d.category, dc.section_title, dc.word_count, "
+                "dc.meeting_id, dc.agenda_item_id, dc.item_number, "
                 "ts_rank(to_tsvector('english', dc.content), "
                 "        plainto_tsquery('english', :q)) AS rank "
                 "FROM document_chunks dc "
@@ -280,6 +281,9 @@ class VectorService:
                         "category": document.category,
                         "section_title": chunk.section_title,
                         "word_count": chunk.word_count,
+                        "meeting_id": chunk.meeting_id,
+                        "agenda_item_id": chunk.agenda_item_id,
+                        "item_number": chunk.item_number,
                     },
                 )
             )
@@ -311,6 +315,7 @@ class VectorService:
             text(
                 "SELECT dc.document_id, dc.chunk_index, dc.content, "
                 "d.document_type, d.category, dc.section_title, dc.word_count, "
+                "dc.meeting_id, dc.agenda_item_id, dc.item_number, "
                 "1 - (dc.embedding <=> CAST(:qvec AS vector)) AS similarity "
                 "FROM document_chunks dc "
                 "JOIN documents d ON d.id = dc.document_id "
@@ -370,6 +375,9 @@ class VectorService:
                         "category": document.category,
                         "section_title": chunk.section_title,
                         "word_count": chunk.word_count,
+                        "meeting_id": chunk.meeting_id,
+                        "agenda_item_id": chunk.agenda_item_id,
+                        "item_number": chunk.item_number,
                     },
                 )
             )
@@ -435,6 +443,9 @@ def _format_result(row: Dict[str, Any], similarity: float) -> Dict[str, Any]:
             "category": row.get("category") or "",
             "section_title": row.get("section_title") or "",
             "word_count": row.get("word_count") or 0,
+            "meeting_id": row.get("meeting_id"),
+            "agenda_item_id": row.get("agenda_item_id"),
+            "item_number": row.get("item_number"),
         },
         "distance": 1.0 - similarity,
         "similarity": similarity,

--- a/backend/app/services/vector_service.py
+++ b/backend/app/services/vector_service.py
@@ -156,19 +156,135 @@ class VectorService:
     async def search_documents(
         self, query: str, top_k: int = 5, filters: Optional[Dict[str, Any]] = None
     ) -> List[Dict[str, Any]]:
-        """Semantic search over stored chunks; returns the top_k matches"""
+        """Hybrid search over stored chunks; returns the top_k matches.
+
+        Dense (semantic) and keyword (full-text) candidates are fused with
+        reciprocal-rank fusion. Keyword search alone still works when no
+        embedding provider is configured, so browse/search stays alive even
+        with zero LLM keys.
+        """
+        candidate_k = max(top_k * 3, 15)
         query_embedding = await self.embedding_service.generate_embedding(query)
-        if not query_embedding:
-            return []
 
         try:
             with self._session() as db:
-                if self._has_pgvector(db):
-                    return self._search_pgvector(db, query_embedding, top_k, filters)
-                return self._search_python(db, query_embedding, top_k, filters)
+                dense: List[Dict[str, Any]] = []
+                if query_embedding:
+                    if self._has_pgvector(db):
+                        dense = self._search_pgvector(
+                            db, query_embedding, candidate_k, filters
+                        )
+                    else:
+                        dense = self._search_python(
+                            db, query_embedding, candidate_k, filters
+                        )
+                keyword = self._search_keyword(db, query, candidate_k, filters)
+                return _fuse_results(dense, keyword, top_k)
         except Exception as e:
             logger.error(f"Error searching documents: {e}")
             return []
+
+    def _search_keyword(
+        self,
+        db: Session,
+        query: str,
+        top_k: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Full-text keyword search: Postgres FTS, or ILIKE elsewhere"""
+        try:
+            if db.get_bind().dialect.name == "postgresql":
+                return self._search_fts(db, query, top_k, filters)
+            return self._search_ilike(db, query, top_k, filters)
+        except Exception as e:
+            logger.warning(f"Keyword search failed: {e}")
+            return []
+
+    def _search_fts(
+        self,
+        db: Session,
+        query: str,
+        top_k: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        where = [
+            "d.is_public = TRUE",
+            "to_tsvector('english', dc.content) @@ plainto_tsquery('english', :q)",
+        ]
+        params: Dict[str, Any] = {"q": query, "top_k": top_k}
+        if filters:
+            if filters.get("document_type"):
+                where.append("d.document_type = :document_type")
+                params["document_type"] = filters["document_type"]
+            if filters.get("category"):
+                where.append("d.category = :category")
+                params["category"] = filters["category"]
+
+        rows = db.execute(
+            text(
+                "SELECT dc.document_id, dc.chunk_index, dc.content, "
+                "d.document_type, d.category, dc.section_title, dc.word_count, "
+                "ts_rank(to_tsvector('english', dc.content), "
+                "        plainto_tsquery('english', :q)) AS rank "
+                "FROM document_chunks dc "
+                "JOIN documents d ON d.id = dc.document_id "
+                f"WHERE {' AND '.join(where)} "
+                "ORDER BY rank DESC "
+                "LIMIT :top_k"
+            ),
+            params,
+        ).mappings()
+
+        return [_format_result(dict(row), min(row["rank"], 1.0)) for row in rows]
+
+    def _search_ilike(
+        self,
+        db: Session,
+        query: str,
+        top_k: int,
+        filters: Optional[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Portable keyword fallback: rank by number of matched terms"""
+        terms = [t for t in query.lower().split() if len(t) > 2]
+        if not terms:
+            return []
+
+        from sqlalchemy import or_
+
+        query_db = (
+            db.query(DocumentChunk, Document)
+            .join(Document, Document.id == DocumentChunk.document_id)
+            .filter(Document.is_public.is_(True))
+            .filter(or_(*[DocumentChunk.content.ilike(f"%{t}%") for t in terms]))
+        )
+        if filters:
+            if filters.get("document_type"):
+                query_db = query_db.filter(
+                    Document.document_type == filters["document_type"]
+                )
+            if filters.get("category"):
+                query_db = query_db.filter(Document.category == filters["category"])
+
+        scored = []
+        for chunk, document in query_db.limit(top_k * 5):
+            content_lower = chunk.content.lower()
+            hits = sum(1 for t in terms if t in content_lower)
+            scored.append(
+                (
+                    hits / len(terms),
+                    {
+                        "document_id": chunk.document_id,
+                        "chunk_index": chunk.chunk_index,
+                        "content": chunk.content,
+                        "document_type": document.document_type,
+                        "category": document.category,
+                        "section_title": chunk.section_title,
+                        "word_count": chunk.word_count,
+                    },
+                )
+            )
+        scored.sort(key=lambda item: item[0], reverse=True)
+        return [_format_result(row, score) for score, row in scored[:top_k]]
 
     def _search_pgvector(
         self,
@@ -277,6 +393,28 @@ class VectorService:
         except Exception as e:
             logger.error(f"Error deleting chunk embeddings: {e}")
             return False
+
+
+def _fuse_results(
+    dense: List[Dict[str, Any]],
+    keyword: List[Dict[str, Any]],
+    top_k: int,
+    rrf_k: int = 60,
+) -> List[Dict[str, Any]]:
+    """Reciprocal-rank fusion of dense and keyword result lists"""
+    fused: Dict[str, Dict[str, Any]] = {}
+    scores: Dict[str, float] = {}
+
+    for result_list in (dense, keyword):
+        for rank, result in enumerate(result_list):
+            key = result["id"]
+            scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank + 1)
+            existing = fused.get(key)
+            if existing is None or result["similarity"] > existing["similarity"]:
+                fused[key] = result
+
+    ordered = sorted(fused.values(), key=lambda r: scores[r["id"]], reverse=True)
+    return ordered[:top_k]
 
 
 def _vector_literal(embedding: List[float]) -> str:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,11 +61,26 @@ corpus (the pgvector column is sized from config on fresh databases).
 - **Hybrid retrieval**: dense (pgvector or numpy) ∪ keyword (Postgres FTS
   with GIN index; ILIKE fallback elsewhere), fused with reciprocal-rank
   fusion. Keyword search alone works with zero LLM keys — search before chat.
-- **Citations**: chat document excerpts carry source title, link, and
-  retrieval date. The system prompt forbids inventing figures, votes, or
-  ordinance text: search and cite, or say the corpus lacks the answer.
+- **Legislative identity, not chunk soup**: agendas and minutes are parsed
+  into their agenda tree (`app/services/agenda_parser.py`) and chunked per
+  item; every chunk carries `meeting_id` / `agenda_item_id` / `item_number`,
+  and those keys flow through search-result metadata. Unstructured documents
+  fall back to fixed windows.
+- **Deep links**: `GET /api/v1/meetings/{id}/items[/{item_id}]` is the
+  canonical item record (structured fields + linked excerpts), and the
+  meeting explorer keeps the selected meeting in the URL (`?meeting=<id>`),
+  so citations and alerts land on the item, not the homepage.
+- **Citations**: chat document excerpts carry source title, link, retrieval
+  date, and a meeting-record deep link when identity is known. The system
+  prompt forbids inventing figures, votes, or ordinance text: search and
+  cite, or say the corpus lacks the answer.
 - **Human-gated outreach**: representative emails are drafted and returned
   for review; the platform never sends on a user's behalf.
+- **Eval seed**: `tests/backend/test_retrieval_eval.py` runs a frozen gold
+  set (deterministic embeddings, no network) in CI — recall assertions fail
+  the build when retrieval regresses. The real gold set, co-written with
+  journalists and organizers, extends this corpus without changing the
+  harness.
 
 ## Schema setup
 
@@ -81,8 +96,8 @@ limitation inherited from the PoC.)
 
 | Iteration | Scope | Status |
 |---|---|---|
-| 1 — Evidence layer | provenance, hybrid index, item deep links | **partially shipped** (this branch: provenance, hybrid index, freshness); agenda-item-level parsing still pending |
-| 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | specced in the design sketch |
+| 1 — Evidence layer | provenance, hybrid index, item-level parsing, deep links | **shipped** on this branch (vendor-adapter hardening for TGOV/Granicus feeds remains ongoing) |
+| 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | eval harness seeded (`test_retrieval_eval.py`); the rest specced in the design sketch |
 | 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | PoC subscriptions exist; precision work pending |
 | 4 — Matters graph | track legislative matters across meetings; optional media | not started |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,108 @@
+# CivicSpark AI — Architecture
+
+Design reference: [kaizencode.art/garden/citycamp-ai](https://kaizencode.art/garden/citycamp-ai/)
+— the product sketch this architecture implements incrementally. The core
+principle from that sketch: **structure the corpus, measure failure, then add
+model cleverness — not the reverse.** Chat is one interface over an evidence
+layer; the explorer, search, and watch digests must stay correct even if the
+LLM is offline.
+
+## Runtime shape
+
+```
+Vercel (React SPA, free tier)
+  └─ /api/* rewrite ──► Render Web Service (FastAPI, Docker)
+                          └─ Render Postgres  ◄── the ONLY stateful service
+                               ├─ relational data (users, meetings,
+                               │   campaigns, subscriptions, documents)
+                               ├─ RAG vectors: document_chunks.embedding
+                               │   (pgvector; JSON + numpy cosine fallback)
+                               └─ FTS index (keyword half of hybrid search)
+
+External APIs (all optional; features degrade gracefully):
+  LLM chat        — any OpenAI-compatible endpoint; default Llama 3.3 70B on Groq (free)
+  Embeddings      — any OpenAI-compatible endpoint; default Jina v3 (free tier)
+  Twilio SMS · SMTP email · Geocod.io · Google CSE
+```
+
+No Redis, no Celery, no S3 (local-disk storage by default), no separate
+vector database. Monthly infrastructure cost at small scale: $0.
+
+### Why Postgres for vectors
+
+The proof-of-concept wrote its Chroma/FAISS index to local disk — ephemeral
+on every container platform, so each deploy silently wiped the RAG index.
+Postgres already stores every chunk; keeping the embedding on the chunk row
+makes the index exactly as durable as the data, with one backup story. At
+civic-corpus scale (thousands of chunks, not millions) pgvector with an HNSW
+index is more than sufficient, and the in-process numpy fallback keeps every
+environment (SQLite tests, Postgres without the extension) working.
+
+### LLM provider strategy
+
+All chat and embedding traffic goes through OpenAI-compatible endpoints
+(`app/core/llm.py`), configured by env var:
+
+| Setting | Default |
+|---|---|
+| `LLM_BASE_URL` / `LLM_MODEL` | Groq / `llama-3.3-70b-versatile` |
+| `EMBEDDING_BASE_URL` / `EMBEDDING_MODEL` / `EMBEDDING_DIMENSIONS` | Jina / `jina-embeddings-v3` / 1024 |
+| `OPENAI_API_KEY` | legacy fallback provider |
+
+Swapping to OpenRouter, Together, or a local Ollama is configuration, not
+code. Changing the embedding model/dimensions requires re-embedding the
+corpus (the pgvector column is sized from config on fresh databases).
+
+## Evidence layer (Iteration 1)
+
+- **Provenance**: every document records `content_hash` (sha256) and
+  `retrieved_at`; identical re-uploads are deduplicated;
+  `/api/v1/documents/stats` reports `index_as_of`.
+- **Hybrid retrieval**: dense (pgvector or numpy) ∪ keyword (Postgres FTS
+  with GIN index; ILIKE fallback elsewhere), fused with reciprocal-rank
+  fusion. Keyword search alone works with zero LLM keys — search before chat.
+- **Citations**: chat document excerpts carry source title, link, and
+  retrieval date. The system prompt forbids inventing figures, votes, or
+  ordinance text: search and cite, or say the corpus lacks the answer.
+- **Human-gated outreach**: representative emails are drafted and returned
+  for review; the platform never sends on a user's behalf.
+
+## Schema setup
+
+Fresh databases bootstrap via `create_tables()` (SQLAlchemy `create_all`) at
+startup, then `ensure_pgvector()` idempotently enables the extension, adds
+the `embedding` column, backfills from JSON, and creates the HNSW + FTS
+indexes. Alembic migrations 005–007 mirror the same steps for
+migration-managed databases. (The pre-005 chain assumes tables that
+`create_all` historically made, so it is not runnable from scratch — a known
+limitation inherited from the PoC.)
+
+## Roadmap (from the design sketch)
+
+| Iteration | Scope | Status |
+|---|---|---|
+| 1 — Evidence layer | provenance, hybrid index, item deep links | **partially shipped** (this branch: provenance, hybrid index, freshness); agenda-item-level parsing still pending |
+| 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | specced in the design sketch |
+| 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | PoC subscriptions exist; precision work pending |
+| 4 — Matters graph | track legislative matters across meetings; optional media | not started |
+
+The failure modes in the design sketch are the acceptance tests: if budget
+questions are still answered from chunk soup without citations, it isn't an
+improvement — it's a prettier PoC.
+
+## Local development
+
+```bash
+docker compose up          # pgvector Postgres + API + frontend
+# or natively:
+cd backend && pip install -r requirements-dev.txt && python -m app.main
+cd frontend && npm install && npm run dev
+```
+
+## Deployment
+
+- **Render**: connect the repo as a Blueprint (`render.yaml`) — one web
+  service + one Postgres. Set `LLM_API_KEY` (Groq) and `EMBEDDING_API_KEY`
+  (Jina) in the dashboard.
+- **Vercel**: import the repo (`vercel.json`) — static build of `frontend/`,
+  `/api/*` proxied to the Render service, so no CORS configuration is needed.

--- a/frontend/src/pages/MeetingsPage.tsx
+++ b/frontend/src/pages/MeetingsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { format } from 'date-fns';
 import { apiRequest, API_ENDPOINTS } from '../config/api';
 import { Meeting as BaseMeeting, AgendaItem, SAMPLE_MEETINGS } from '../data/sampleMeetings';
@@ -32,6 +33,9 @@ interface Meeting extends BaseMeeting {
 }
 
 export const MeetingsPage: React.FC = () => {
+  // The selected meeting lives in the URL (?meeting=<id>) so agendas and
+  // minutes are deep-linkable from chat citations, alerts, and shared links.
+  const [searchParams, setSearchParams] = useSearchParams();
   const [meetings, setMeetings] = useState<Meeting[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -458,9 +462,29 @@ export const MeetingsPage: React.FC = () => {
     // Only fetch if not already selected
     if (selectedMeeting?.id !== meetingId) {
       console.log('Meeting clicked:', meetingId);
+      setSearchParams(prev => {
+        const params = new URLSearchParams(prev);
+        params.set('meeting', String(meetingId));
+        return params;
+      });
       fetchMeetingDetails(meetingId);
     }
-  }, [selectedMeeting?.id, fetchMeetingDetails]);
+  }, [selectedMeeting?.id, fetchMeetingDetails, setSearchParams]);
+
+  // Deep-link support: opening /meetings?meeting=<id> (from a chat
+  // citation, alert email, or shared link) selects that meeting directly.
+  useEffect(() => {
+    const meetingParam = searchParams.get('meeting');
+    if (meetingParam) {
+      const meetingId = Number(meetingParam);
+      if (!Number.isNaN(meetingId) && selectedMeeting?.id !== meetingId) {
+        fetchMeetingDetails(meetingId);
+      }
+    } else if (selectedMeeting) {
+      setSelectedMeeting(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, fetchMeetingDetails]);
 
   if (loading) {
     return (

--- a/tests/backend/test_agenda_parser.py
+++ b/tests/backend/test_agenda_parser.py
@@ -1,0 +1,94 @@
+"""Tests for structure-aware agenda parsing (the chunk-soup fix)."""
+
+import sys
+from pathlib import Path
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.services.agenda_parser import (  # noqa: E402
+    item_chunk_title,
+    normalize_item_number,
+    parse_agenda_items,
+)
+
+SAMPLE_AGENDA = """
+TULSA CITY COUNCIL
+REGULAR MEETING AGENDA
+Wednesday, June 4, 2025, 5:00 PM
+One Technology Center, 175 E 2nd St
+
+CONSENT AGENDA
+
+1. Approval of the minutes of the May 28, 2025 regular meeting.
+The minutes were distributed to all councilors in advance.
+
+2. Ordinance approving a rezoning at 4501 S Peoria Ave from RS-3 to CH.
+Application Z-7642 by Peoria Partners LLC. The Planning Commission
+recommended approval by a vote of 8-1 on May 15, 2025.
+
+PUBLIC HEARINGS
+
+3. Public hearing on the FY 2025-2026 annual budget.
+The proposed budget totals $1.117 billion including a $380 million
+allocation for public safety.
+
+3.a. Amendment to increase the street resurfacing program by $5 million.
+Proposed by Councilor Lakin, seconded by Councilor Gilbert.
+
+4. Resolution authorizing an agreement with Tulsa Transit for bus
+rapid transit planning along the Peoria corridor.
+
+Page 1 of 1
+"""
+
+
+def test_parses_numbered_items():
+    items = parse_agenda_items(SAMPLE_AGENDA)
+    numbers = [item.item_number for item in items]
+    assert numbers == ["1", "2", "3", "3.a", "4"]
+
+
+def test_items_carry_section_headings():
+    items = parse_agenda_items(SAMPLE_AGENDA)
+    by_number = {item.item_number: item for item in items}
+    assert by_number["1"].section == "CONSENT AGENDA"
+    assert by_number["2"].section == "CONSENT AGENDA"
+    assert by_number["3"].section == "PUBLIC HEARINGS"
+
+
+def test_item_bodies_capture_following_text():
+    items = parse_agenda_items(SAMPLE_AGENDA)
+    rezoning = next(item for item in items if item.item_number == "2")
+    assert "Planning Commission" in rezoning.text
+    budget = next(item for item in items if item.item_number == "3")
+    assert "$1.117 billion" in budget.text
+
+
+def test_page_noise_is_dropped():
+    items = parse_agenda_items(SAMPLE_AGENDA)
+    all_text = " ".join(item.text for item in items)
+    assert "Page 1 of 1" not in all_text
+
+
+def test_unstructured_text_returns_empty():
+    prose = (
+        "The city of Tulsa has a long history of civic engagement. "
+        "Many residents attend council meetings. "
+        "This document contains no numbered agenda items at all."
+    )
+    assert parse_agenda_items(prose) == []
+
+
+def test_normalize_item_number():
+    assert normalize_item_number("2.A.") == "2.a"
+    assert normalize_item_number("3.a)") == "3.a"
+    assert normalize_item_number("12.") == "12"
+
+
+def test_item_chunk_title_includes_section_and_number():
+    items = parse_agenda_items(SAMPLE_AGENDA)
+    rezoning = next(item for item in items if item.item_number == "2")
+    title = item_chunk_title(rezoning)
+    assert title.startswith("CONSENT AGENDA — Item 2:")
+    assert "rezoning" in title.lower()

--- a/tests/backend/test_document_pipeline.py
+++ b/tests/backend/test_document_pipeline.py
@@ -1,0 +1,54 @@
+"""Tests for structure-aware document chunking in the processing pipeline."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+sys.path.insert(0, str(Path(__file__).parent))
+
+from app.core.config import Settings  # noqa: E402
+from app.services.document_processing_service import (  # noqa: E402
+    DocumentProcessingService,
+)
+from test_agenda_parser import SAMPLE_AGENDA  # noqa: E402
+
+
+@pytest.fixture
+def processing_service():
+    return DocumentProcessingService(Settings(), db=None)
+
+
+def test_agenda_documents_chunk_by_item(processing_service):
+    chunks = processing_service._chunk_document(SAMPLE_AGENDA, "agenda")
+
+    item_numbers = {chunk.get("item_number") for chunk in chunks}
+    assert {"1", "2", "3", "3.a", "4"} <= item_numbers
+    assert all(chunk.get("section_type") == "agenda_item" for chunk in chunks)
+    # Chunk indexes are sequential across the whole document
+    assert [chunk["chunk_index"] for chunk in chunks] == list(range(len(chunks)))
+
+    rezoning = next(chunk for chunk in chunks if chunk["item_number"] == "2")
+    assert "Item 2:" in rezoning["section_title"]
+    assert "rezoning" in rezoning["content"].lower()
+
+
+def test_minutes_use_same_structure_path(processing_service):
+    chunks = processing_service._chunk_document(SAMPLE_AGENDA, "meeting_minutes")
+    assert any(chunk.get("item_number") for chunk in chunks)
+
+
+def test_unstructured_documents_fall_back_to_windows(processing_service):
+    prose = " ".join(
+        f"Sentence {i} about the city of Tulsa and its many programs." for i in range(50)
+    )
+    chunks = processing_service._chunk_document(prose, "agenda")
+    assert chunks
+    assert all(chunk.get("item_number") is None for chunk in chunks)
+
+
+def test_non_agenda_types_use_fixed_windows(processing_service):
+    chunks = processing_service._chunk_document(SAMPLE_AGENDA, "budget")
+    assert all(chunk.get("item_number") is None for chunk in chunks)

--- a/tests/backend/test_retrieval_eval.py
+++ b/tests/backend/test_retrieval_eval.py
@@ -1,0 +1,144 @@
+"""Seed of the retrieval eval harness: a frozen gold set run in CI.
+
+Uses deterministic bag-of-words "embeddings" over a tiny fixed civic
+corpus, so hybrid retrieval quality (dense + keyword + fusion) is
+regression-tested without any LLM keys or network. The real gold set —
+co-written with journalists and organizers per the design sketch — will
+extend this file's corpus and queries; the harness stays the same.
+
+If a retrieval change makes these assertions fail, it made civic answers
+worse. Fix the change, don't loosen the gold set.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings  # noqa: E402
+from app.core.database import Base  # noqa: E402
+from app.models.document import Document, DocumentChunk  # noqa: E402
+from app.services.vector_service import VectorService  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+# Deterministic embedding: term counts along fixed topic axes.
+VOCABULARY = [
+    "parks", "budget", "police", "transit", "zoning",
+    "water", "housing", "library", "curfew", "audit",
+]
+
+
+def embed(text: str) -> list:
+    words = text.lower().split()
+    vector = [float(sum(1 for w in words if term in w)) for term in VOCABULARY]
+    return vector if any(vector) else [1e-6] * len(VOCABULARY)
+
+
+# Frozen corpus: (document_type, content)
+CORPUS = [
+    ("budget", "The FY2026 budget allocates 45 million dollars to parks and recreation"),
+    ("budget", "Police department budget increased to 240 million dollars for FY2026"),
+    ("meeting_minutes", "Council approved the bus rapid transit corridor on Peoria Avenue"),
+    ("meeting_minutes", "Public hearing on rezoning application Z-7642 near 41st and Peoria"),
+    ("policy", "Water and sewer rate adjustments take effect in January"),
+    ("meeting_minutes", "Council adopted a downtown curfew for minors from June to October"),
+    ("report", "The city auditor released findings on housing program spending"),
+]
+
+# Gold queries: query text -> substring that must appear in the top results.
+GOLD = [
+    ("parks budget", "parks and recreation", 1),
+    ("police spending", "Police department budget", 1),
+    ("bus rapid transit Peoria", "bus rapid transit", 1),
+    ("rezoning Z-7642", "Z-7642", 1),
+    ("water rates", "Water and sewer rate", 1),
+    ("downtown curfew minors", "downtown curfew", 1),
+    ("audit housing", "auditor released findings", 1),
+]
+
+RECALL_K = 3
+
+
+@pytest.fixture
+def seeded_service():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    for i, (doc_type, content) in enumerate(CORPUS, start=1):
+        session.add(
+            Document(
+                id=i,
+                title=f"Doc {i}",
+                content=content,
+                document_type=doc_type,
+                is_public=True,
+            )
+        )
+        session.add(
+            DocumentChunk(
+                document_id=i,
+                chunk_index=0,
+                content=content,
+                embedding_vector=embed(content),
+            )
+        )
+    session.commit()
+
+    service = VectorService(Settings(), db=session)
+    yield service
+    session.close()
+
+
+@pytest.mark.asyncio
+async def test_gold_set_recall(seeded_service):
+    """Every gold query must surface its target within the top RECALL_K"""
+    misses = []
+    for query, expected_substring, _ in GOLD:
+        seeded_service.embedding_service.generate_embedding = AsyncMock(
+            return_value=embed(query)
+        )
+        results = await seeded_service.search_documents(query, top_k=RECALL_K)
+        contents = [result["content"] for result in results]
+        if not any(expected_substring in content for content in contents):
+            misses.append((query, expected_substring, contents))
+
+    assert not misses, f"Gold-set retrieval misses: {misses}"
+
+
+@pytest.mark.asyncio
+async def test_gold_set_recall_without_embeddings(seeded_service):
+    """Keyword-only degradation still finds most gold answers (search
+    before chat: the corpus must stay useful with zero LLM keys)"""
+    hits = 0
+    for query, expected_substring, _ in GOLD:
+        seeded_service.embedding_service.generate_embedding = AsyncMock(
+            return_value=[]
+        )
+        results = await seeded_service.search_documents(query, top_k=RECALL_K)
+        if any(expected_substring in r["content"] for r in results):
+            hits += 1
+
+    assert hits >= len(GOLD) - 2, (
+        f"Keyword-only recall degraded: {hits}/{len(GOLD)} gold queries hit"
+    )
+
+
+@pytest.mark.asyncio
+async def test_type_filter_respected(seeded_service):
+    """Filters are part of the retrieval contract"""
+    seeded_service.embedding_service.generate_embedding = AsyncMock(
+        return_value=embed("budget")
+    )
+    results = await seeded_service.search_documents(
+        "budget", top_k=5, filters={"document_type": "budget"}
+    )
+    assert results
+    assert all(
+        result["metadata"]["document_type"] == "budget" for result in results
+    )

--- a/tests/backend/test_vector_service.py
+++ b/tests/backend/test_vector_service.py
@@ -147,7 +147,46 @@ async def test_search_excludes_private_documents(db_session, vector_service):
 
 
 @pytest.mark.asyncio
-async def test_search_returns_empty_without_embeddings(db_session, vector_service):
+async def test_keyword_search_works_without_embedding_provider(
+    db_session, vector_service
+):
+    """Search-before-chat: the corpus stays searchable with zero LLM keys"""
+    _make_document(db_session, 1)
+    _make_chunk(db_session, 1, 0, "The parks and recreation budget increased")
+    _make_chunk(db_session, 1, 1, "Airport authority quarterly report")
+
+    vector_service.embedding_service.generate_embedding = AsyncMock(return_value=[])
+
+    results = await vector_service.search_documents("parks budget", top_k=5)
+
+    assert len(results) == 1
+    assert "parks" in results[0]["content"].lower()
+
+
+@pytest.mark.asyncio
+async def test_hybrid_fuses_dense_and_keyword(db_session, vector_service):
+    _make_document(db_session, 1)
+    semantic_hit = _make_chunk(db_session, 1, 0, "funding for green spaces")
+    keyword_hit = _make_chunk(db_session, 1, 1, "the parks department update")
+    semantic_hit.embedding_vector = [1.0, 0.0]
+    keyword_hit.embedding_vector = [0.0, 1.0]
+    db_session.commit()
+
+    vector_service.embedding_service.generate_embedding = AsyncMock(
+        return_value=[1.0, 0.0]
+    )
+
+    results = await vector_service.search_documents("parks", top_k=5)
+
+    contents = {result["content"] for result in results}
+    # Dense retrieval surfaces the semantic hit; keyword retrieval surfaces
+    # the literal match; fusion returns both.
+    assert "funding for green spaces" in contents
+    assert "the parks department update" in contents
+
+
+@pytest.mark.asyncio
+async def test_search_returns_empty_on_empty_corpus(db_session, vector_service):
     vector_service.embedding_service.generate_embedding = AsyncMock(return_value=[])
     results = await vector_service.search_documents("anything")
     assert results == []


### PR DESCRIPTION
Implements Iteration 1 of the design sketch (kaizencode.art/garden/citycamp-ai): structure the corpus before adding model cleverness. Chat is one interface over an evidence layer that must stay correct even if the LLM is offline.

## Changes

- **Provenance**: every document records `content_hash` (sha256) + `retrieved_at`; identical re-uploads deduplicate; `/documents/stats` reports `index_as_of`
- **Hybrid retrieval**: dense (pgvector/numpy) ∪ keyword (Postgres FTS with GIN index; ILIKE fallback) fused with reciprocal-rank fusion — the corpus stays searchable with zero LLM keys
- **Legislative identity, not chunk soup**: agendas/minutes are parsed into their agenda tree (`agenda_parser.py`) and chunked per item; every chunk carries `meeting_id` / `agenda_item_id` / `item_number` through search metadata
- **Deep links**: `GET /meetings/{id}/items[/{item_id}]` canonical item records; the meeting explorer keeps selection in the URL (`?meeting=<id>`); chat citations link to the meeting record
- **Cited excerpts**: chat document results carry source title, link, and retrieval date; empty results point to official city sites instead of guessing
- **Eval seed**: frozen retrieval gold set runs in CI with deterministic embeddings — recall regressions fail the build

## Verification

Full backend suite (34 tests at this point) passes, including agenda-parser, pipeline-chunking, and gold-set recall tests; frontend type-checks.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_