### PR TITLE
Iteration 2: grounded Q&A

### DIFF
--- a/backend/alembic/versions/009_add_budget_lines.py
+++ b/backend/alembic/versions/009_add_budget_lines.py
@@ -1,0 +1,43 @@
+"""Add budget_lines table for structured budget facts
+
+Dollar figures come from table cells, not free-text generation. Each row
+keeps a pointer to its source document/page so figures stay auditable.
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "009"
+down_revision = "008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "budget_lines",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("fiscal_year", sa.String(20), nullable=False, index=True),
+        sa.Column("fund", sa.String(200), index=True),
+        sa.Column("department", sa.String(200), index=True),
+        sa.Column("category", sa.String(200), index=True),
+        sa.Column("description", sa.Text()),
+        sa.Column("amount", sa.Numeric(16, 2), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=True),
+        sa.Column("page", sa.Integer(), nullable=True),
+        sa.Column("source_url", sa.String(1000)),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("budget_lines")

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from .endpoints import (
     auth,
+    budget,
     campaigns,
     chatbot,
     documents,
@@ -34,6 +35,7 @@ api_router.include_router(
 )
 api_router.include_router(campaigns.router, prefix="/campaigns", tags=["campaigns"])
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
+api_router.include_router(budget.router, prefix="/budget", tags=["budget"])
 
 # TODO: Add other routers as they are created
 # api_router.include_router(users.router, prefix="/users", tags=["users"])

--- a/backend/app/api/v1/endpoints/budget.py
+++ b/backend/app/api/v1/endpoints/budget.py
@@ -1,0 +1,124 @@
+"""Structured budget data endpoints.
+
+Read access is public (it's the city budget); imports are admin-only.
+"""
+
+from typing import Optional
+
+from app.core.database import get_db
+from app.models.budget import BudgetLine
+from app.models.user import User
+from app.services.auth import get_current_admin_user
+from app.services.budget_service import import_budget_csv, lookup_budget_lines
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+router = APIRouter()
+
+
+@router.get("/lines")
+async def list_budget_lines(
+    fiscal_year: Optional[str] = Query(None),
+    fund: Optional[str] = Query(None),
+    department: Optional[str] = Query(None),
+    q: Optional[str] = Query(None, description="Keyword over description/category"),
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+):
+    """Query structured budget lines"""
+    lines = lookup_budget_lines(
+        db,
+        fiscal_year=fiscal_year,
+        fund=fund,
+        department=department,
+        keyword=q,
+        limit=limit,
+    )
+    return {
+        "lines": [
+            {
+                "id": line.id,
+                "fiscal_year": line.fiscal_year,
+                "fund": line.fund,
+                "department": line.department,
+                "category": line.category,
+                "description": line.description,
+                "amount": float(line.amount),
+                "source_url": line.source_url,
+                "page": line.page,
+                "document_id": line.document_id,
+            }
+            for line in lines
+        ],
+        "total": len(lines),
+    }
+
+
+@router.get("/years")
+async def list_fiscal_years(db: Session = Depends(get_db)):
+    """Distinct fiscal years available in the structured budget table"""
+    years = [
+        row[0]
+        for row in db.query(BudgetLine.fiscal_year)
+        .distinct()
+        .order_by(BudgetLine.fiscal_year.desc())
+        .all()
+    ]
+    return {"fiscal_years": years}
+
+
+@router.get("/summary")
+async def budget_summary(
+    fiscal_year: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Totals by department for a fiscal year (defaults to the newest)"""
+    if fiscal_year is None:
+        latest = (
+            db.query(BudgetLine.fiscal_year)
+            .distinct()
+            .order_by(BudgetLine.fiscal_year.desc())
+            .first()
+        )
+        if latest is None:
+            return {"fiscal_year": None, "departments": []}
+        fiscal_year = latest[0]
+
+    rows = (
+        db.query(BudgetLine.department, func.sum(BudgetLine.amount))
+        .filter(BudgetLine.fiscal_year == fiscal_year)
+        .group_by(BudgetLine.department)
+        .order_by(func.sum(BudgetLine.amount).desc())
+        .all()
+    )
+    return {
+        "fiscal_year": fiscal_year,
+        "departments": [
+            {"department": dept or "(unassigned)", "total": float(total)}
+            for dept, total in rows
+        ],
+    }
+
+
+@router.post("/import")
+async def import_budget(
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Import budget lines from a CSV file (admin only).
+
+    Header: fiscal_year, amount [, fund, department, category,
+    description, source_url, page, document_id]
+    """
+    raw = await file.read()
+    try:
+        csv_text = raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise HTTPException(status_code=400, detail="CSV must be UTF-8 encoded")
+
+    result = import_budget_csv(db, csv_text)
+    if result["imported"] == 0 and result["errors"]:
+        raise HTTPException(status_code=400, detail=result)
+    return result

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -92,6 +92,8 @@ class Settings(BaseSettings):
 
     # RAG Configuration
     enable_rag: bool = True
+    # Second-pass claim verification on tool-grounded answers (refuse > invent)
+    enable_claim_verification: bool = True
     max_tokens: int = 4000
     temperature: float = 0.7
     chunk_size: int = 1000

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from .budget import BudgetLine
 from .campaign import (
     Campaign,
     CampaignMembership,
@@ -18,6 +19,7 @@ from .subscription import MeetingTopic, NotificationLog, TopicSubscription
 from .user import User, UserInterests
 
 __all__ = [
+    "BudgetLine",
     "User",
     "UserInterests",
     "Meeting",

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -1,0 +1,49 @@
+from app.core.database import Base
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+
+class BudgetLine(Base):
+    """One line of a city budget, as structured data.
+
+    Dollar figures the chatbot cites must come from rows in this table
+    (via the lookup_budget_line tool), never from free-text generation
+    over PDF chunks. Rows keep a pointer to the source document/page so
+    every number remains auditable.
+    """
+
+    __tablename__ = "budget_lines"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    fiscal_year = Column(String(20), nullable=False, index=True)  # e.g. "FY2026"
+    fund = Column(String(200), index=True)  # e.g. "General Fund"
+    department = Column(String(200), index=True)  # e.g. "Police"
+    category = Column(String(200), index=True)  # e.g. "Personnel Services"
+    description = Column(Text)  # free-text line description
+    amount = Column(Numeric(16, 2), nullable=False)
+
+    # Provenance: where this figure came from.
+    document_id = Column(Integer, ForeignKey("documents.id"), nullable=True)
+    page = Column(Integer, nullable=True)
+    source_url = Column(String(1000))
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    document = relationship("Document")
+
+    def __repr__(self):
+        return (
+            f"<BudgetLine({self.fiscal_year} {self.department or self.fund}: "
+            f"{self.amount})>"
+        )

--- a/backend/app/services/budget_service.py
+++ b/backend/app/services/budget_service.py
@@ -1,0 +1,157 @@
+"""Structured budget data: import and lookup.
+
+The chatbot's lookup_budget_line tool reads from here; the LLM never
+"remembers" a dollar amount that didn't come from a row in the
+budget_lines table.
+"""
+
+import csv
+import io
+import logging
+from decimal import Decimal, InvalidOperation
+from typing import Any, Dict, List, Optional
+
+from app.models.budget import BudgetLine
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_COLUMNS = {"fiscal_year", "amount"}
+OPTIONAL_COLUMNS = {
+    "fund",
+    "department",
+    "category",
+    "description",
+    "source_url",
+    "page",
+    "document_id",
+}
+
+
+def import_budget_csv(db: Session, csv_text: str) -> Dict[str, Any]:
+    """Import budget lines from CSV text.
+
+    Expected header: fiscal_year, amount, and any of fund, department,
+    category, description, source_url, page, document_id. Returns a
+    summary with imported/skipped counts and row-level errors.
+    """
+    reader = csv.DictReader(io.StringIO(csv_text))
+    if reader.fieldnames is None:
+        return {"imported": 0, "skipped": 0, "errors": ["empty file"]}
+
+    fieldnames = {name.strip().lower() for name in reader.fieldnames}
+    missing = REQUIRED_COLUMNS - fieldnames
+    if missing:
+        return {
+            "imported": 0,
+            "skipped": 0,
+            "errors": [f"missing required columns: {', '.join(sorted(missing))}"],
+        }
+
+    imported = 0
+    skipped = 0
+    errors: List[str] = []
+
+    for line_number, row in enumerate(reader, start=2):
+        normalized = {
+            (key or "").strip().lower(): (value or "").strip()
+            for key, value in row.items()
+        }
+        try:
+            amount = Decimal(normalized["amount"].replace(",", "").replace("$", ""))
+        except (InvalidOperation, KeyError):
+            skipped += 1
+            errors.append(f"row {line_number}: unparseable amount")
+            continue
+
+        fiscal_year = normalized.get("fiscal_year", "")
+        if not fiscal_year:
+            skipped += 1
+            errors.append(f"row {line_number}: missing fiscal_year")
+            continue
+
+        db.add(
+            BudgetLine(
+                fiscal_year=fiscal_year,
+                fund=normalized.get("fund") or None,
+                department=normalized.get("department") or None,
+                category=normalized.get("category") or None,
+                description=normalized.get("description") or None,
+                amount=amount,
+                source_url=normalized.get("source_url") or None,
+                page=int(normalized["page"]) if normalized.get("page") else None,
+                document_id=(
+                    int(normalized["document_id"])
+                    if normalized.get("document_id")
+                    else None
+                ),
+            )
+        )
+        imported += 1
+
+    db.commit()
+    return {"imported": imported, "skipped": skipped, "errors": errors[:20]}
+
+
+def lookup_budget_lines(
+    db: Session,
+    fiscal_year: Optional[str] = None,
+    fund: Optional[str] = None,
+    department: Optional[str] = None,
+    keyword: Optional[str] = None,
+    limit: int = 20,
+) -> List[BudgetLine]:
+    """Query budget lines with case-insensitive partial matching"""
+    query = db.query(BudgetLine)
+    if fiscal_year:
+        query = query.filter(BudgetLine.fiscal_year.ilike(f"%{fiscal_year}%"))
+    if fund:
+        query = query.filter(BudgetLine.fund.ilike(f"%{fund}%"))
+    if department:
+        query = query.filter(BudgetLine.department.ilike(f"%{department}%"))
+    if keyword:
+        pattern = f"%{keyword}%"
+        query = query.filter(
+            or_(
+                BudgetLine.description.ilike(pattern),
+                BudgetLine.category.ilike(pattern),
+                BudgetLine.department.ilike(pattern),
+                BudgetLine.fund.ilike(pattern),
+            )
+        )
+    return query.order_by(BudgetLine.fiscal_year.desc(), BudgetLine.amount.desc()).limit(
+        limit
+    ).all()
+
+
+def format_budget_lines(lines: List[BudgetLine]) -> str:
+    """Render lookup results for the chatbot, with per-row provenance"""
+    if not lines:
+        return (
+            "No matching budget lines in the structured budget table. "
+            "Do not guess a figure; point the user to "
+            "https://www.cityoftulsa.org/budget-documents instead."
+        )
+
+    formatted = "Budget lines (structured data — cite these figures exactly):\n\n"
+    for line in lines:
+        parts = [line.fiscal_year]
+        if line.fund:
+            parts.append(line.fund)
+        if line.department:
+            parts.append(line.department)
+        if line.category:
+            parts.append(line.category)
+        formatted += f"- {' · '.join(parts)}: ${line.amount:,.2f}"
+        if line.description:
+            formatted += f" — {line.description}"
+        provenance = []
+        if line.source_url:
+            provenance.append(line.source_url)
+        if line.page:
+            provenance.append(f"p.{line.page}")
+        if provenance:
+            formatted += f" [source: {' '.join(provenance)}]"
+        formatted += "\n"
+    return formatted

--- a/backend/app/services/chatbot_service.py
+++ b/backend/app/services/chatbot_service.py
@@ -1,15 +1,20 @@
 import asyncio
 import json
 import logging
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from app.core.config import Settings
 from app.core.llm import get_chat_client
 from app.models.campaign import Campaign
 from app.models.document import Document
-from app.models.meeting import Meeting
+from app.models.meeting import AgendaItem, Meeting
+from app.services.agenda_parser import normalize_item_number
+from app.services.budget_service import format_budget_lines, lookup_budget_lines
+from app.services.intent_router import classify_intent
 from app.services.research_service import ResearchService
 from app.services.vector_service import VectorService
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -40,7 +45,8 @@ class ChatbotService:
 You have extensive knowledge about Tulsa government, civic processes, city services, local politics, and community engagement opportunities. Feel free to provide detailed, conversational responses that help people understand and get involved in their local government.
 
 RESPONSE APPROACH:
-- **Never invent specific figures, vote outcomes, or ordinance text.** For dollar amounts, budget lines, or what the law says, use document search and cite the source; if the corpus doesn't contain the answer, say so plainly and point to the official source (cityoftulsa.org, tulsacouncil.org) instead of guessing
+- **Never invent specific figures, vote outcomes, or ordinance text.** For dollar amounts use the lookup_budget_line tool; for what Council did use document search and get_agenda_item; cite the source. If the corpus doesn't contain the answer, say so plainly and point to the official source (cityoftulsa.org, tulsacouncil.org) instead of guessing
+- **Contested topics** (housing, policing, public safety, budgets, accountability): do not soft-pedal, evade, or take sides. Present what Council actually did (with citations) as distinct from what advocates or officials claim; surface staff reports and public comment records when they exist in the corpus; if the corpus only covers one side, say so. You serve residents' right to know, not the city's narrative
 - Be conversational, helpful, and encouraging
 - Provide as much detail as needed to fully answer questions
 - Use your knowledge to give comprehensive, nuanced responses
@@ -412,6 +418,83 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                     "required": ["url"],
                 },
             },
+            {
+                "name": "lookup_budget_line",
+                "description": (
+                    "Look up exact dollar figures from the structured city "
+                    "budget table. ALWAYS use this for budget amounts - "
+                    "never state a dollar figure that did not come from "
+                    "this tool or a cited document."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "fiscal_year": {
+                            "type": "string",
+                            "description": "Fiscal year, e.g. FY2026 or 2025-2026",
+                        },
+                        "fund": {
+                            "type": "string",
+                            "description": "Fund name, e.g. General Fund",
+                        },
+                        "department": {
+                            "type": "string",
+                            "description": "Department, e.g. Police, Parks",
+                        },
+                        "keyword": {
+                            "type": "string",
+                            "description": "Keyword over line descriptions/categories",
+                        },
+                    },
+                },
+            },
+            {
+                "name": "get_agenda_item",
+                "description": (
+                    "Get the canonical record for one agenda item of a "
+                    "meeting: title, vote result, and deep link. Use when "
+                    "the user asks what happened with a specific item."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "meeting_id": {
+                            "type": "integer",
+                            "description": "Meeting ID",
+                        },
+                        "item_number": {
+                            "type": "string",
+                            "description": "Agenda item number, e.g. '2.a'",
+                        },
+                    },
+                    "required": ["meeting_id"],
+                },
+            },
+            {
+                "name": "search_meetings",
+                "description": (
+                    "Find city council meetings by topic keyword and date "
+                    "range. Returns meeting titles, dates, and deep links."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "Topic or keyword, e.g. housing, curfew",
+                        },
+                        "date_from": {
+                            "type": "string",
+                            "description": "Earliest meeting date, ISO format",
+                        },
+                        "date_to": {
+                            "type": "string",
+                            "description": "Latest meeting date, ISO format",
+                        },
+                    },
+                    "required": ["topic"],
+                },
+            },
         ]
 
     async def process_function_call(
@@ -512,12 +595,115 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                 document = await self.research_service.retrieve_document(url)
                 return self.research_service.format_document_content(document)
 
+            elif function_name == "lookup_budget_line":
+                lines = lookup_budget_lines(
+                    self.db,
+                    fiscal_year=arguments.get("fiscal_year"),
+                    fund=arguments.get("fund"),
+                    department=arguments.get("department"),
+                    keyword=arguments.get("keyword"),
+                )
+                return format_budget_lines(lines)
+
+            elif function_name == "get_agenda_item":
+                return self._get_agenda_item(
+                    arguments.get("meeting_id"), arguments.get("item_number")
+                )
+
+            elif function_name == "search_meetings":
+                return self._search_meetings(
+                    arguments.get("topic", ""),
+                    arguments.get("date_from"),
+                    arguments.get("date_to"),
+                )
+
             else:
                 return f"Unknown function: {function_name}"
 
         except Exception as e:
             logger.error(f"Error processing function call {function_name}: {e}")
             return f"Error executing {function_name}: {str(e)}"
+
+    def _get_agenda_item(self, meeting_id, item_number) -> str:
+        """Canonical agenda-item record for the get_agenda_item tool"""
+        if not meeting_id:
+            return "meeting_id is required."
+
+        query = self.db.query(AgendaItem).filter(AgendaItem.meeting_id == meeting_id)
+        item = None
+        if item_number:
+            wanted = normalize_item_number(str(item_number))
+            for candidate in query.all():
+                if (
+                    candidate.item_number
+                    and normalize_item_number(candidate.item_number) == wanted
+                ):
+                    item = candidate
+                    break
+        else:
+            item = query.first()
+
+        if item is None:
+            return (
+                f"No agenda item matching '{item_number}' found for meeting "
+                f"{meeting_id}. Do not guess its outcome."
+            )
+
+        meeting = self.db.query(Meeting).filter(Meeting.id == meeting_id).first()
+        result = f"Agenda item {item.item_number or item.id}: {item.title}\n"
+        if meeting:
+            result += (
+                f"Meeting: {meeting.title} on "
+                f"{meeting.meeting_date.strftime('%B %d, %Y')}\n"
+            )
+        if item.description:
+            result += f"Description: {item.description[:400]}\n"
+        if item.vote_result:
+            result += f"Vote result: {item.vote_result}\n"
+        if item.vote_details:
+            result += f"Vote details: {json.dumps(item.vote_details)[:400]}\n"
+        if item.summary:
+            result += f"Summary: {item.summary[:400]}\n"
+        result += f"Deep link: /meetings?meeting={meeting_id}\n"
+        return result
+
+    def _search_meetings(self, topic: str, date_from, date_to) -> str:
+        """Temporal meeting browse for the search_meetings tool"""
+        if not topic.strip():
+            return "topic is required."
+
+        pattern = f"%{topic}%"
+        query = self.db.query(Meeting).filter(
+            or_(
+                Meeting.title.ilike(pattern),
+                Meeting.summary.ilike(pattern),
+                Meeting.description.ilike(pattern),
+            )
+        )
+        try:
+            if date_from:
+                query = query.filter(
+                    Meeting.meeting_date >= datetime.fromisoformat(date_from)
+                )
+            if date_to:
+                query = query.filter(
+                    Meeting.meeting_date <= datetime.fromisoformat(date_to)
+                )
+        except ValueError:
+            return "Dates must be in ISO format (YYYY-MM-DD)."
+
+        meetings = query.order_by(Meeting.meeting_date.desc()).limit(5).all()
+        if not meetings:
+            return f"No meetings matching '{topic}' in the indexed record."
+
+        result = f"Meetings matching '{topic}':\n"
+        for meeting in meetings:
+            result += (
+                f"- {meeting.title} — "
+                f"{meeting.meeting_date.strftime('%B %d, %Y')} "
+                f"(deep link: /meetings?meeting={meeting.id})\n"
+            )
+        return result
 
     def _get_context_from_recent_meetings(self) -> str:
         """Get context from recent meetings to help answer questions"""
@@ -584,18 +770,26 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
 
             system_prompt = self.get_system_prompt()
 
-            # Skip database context queries for faster responses
-            # TODO: Re-enable when database performance is optimized
-            # meeting_context = self._get_context_from_recent_meetings()
-            # campaign_context = self._get_context_from_campaigns()
-
-            # Build messages for OpenAI
+            # Build messages
             messages = [
                 {
                     "role": "system",
                     "content": system_prompt,
                 }
             ]
+
+            # Route intent: budget facts go to the structured budget tool,
+            # outcome questions to minutes, etc. The guidance rides along
+            # as a system message rather than forcing tool_choice, so the
+            # model can still decline gracefully.
+            intent = classify_intent(user_message)
+            if intent.guidance:
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": f"[intent: {intent.name}] {intent.guidance}",
+                    }
+                )
 
             # Add conversation history if provided
             if conversation_history:
@@ -613,44 +807,87 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
             messages.append({"role": "user", "content": user_message})
 
             logger.info(
-                f"Calling {self.model} with {len(messages)} messages..."
+                f"Calling {self.model} (intent: {intent.name}) with "
+                f"{len(messages)} messages..."
             )
 
-            # Enable tool-calling RAG only when configured
-            if self.settings.enable_rag:
-                response = self.client.chat.completions.create(
+            # Agent loop: the model may call tools; results are fed back so
+            # the final answer is synthesized WITH its evidence, instead of
+            # dumping raw tool output at the user.
+            evidence: List[str] = []
+            ai_response = None
+            max_tool_rounds = 3
+
+            for round_index in range(max_tool_rounds + 1):
+                tools_enabled = (
+                    self.settings.enable_rag and round_index < max_tool_rounds
+                )
+                request_kwargs: Dict[str, Any] = dict(
                     model=self.model,
                     messages=messages,
                     max_tokens=800,
                     temperature=0.7,
-                    tools=self.get_tool_definitions(),
-                    tool_choice="auto",
                 )
-            else:
-                response = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    max_tokens=800,
-                    temperature=0.7,
+                if tools_enabled:
+                    request_kwargs["tools"] = self.get_tool_definitions()
+                    request_kwargs["tool_choice"] = "auto"
+
+                response = self.client.chat.completions.create(**request_kwargs)
+                message = response.choices[0].message
+                tool_calls = getattr(message, "tool_calls", None)
+
+                if not (tools_enabled and tool_calls):
+                    ai_response = (message.content or "").strip()
+                    break
+
+                # Execute the requested tools and feed results back.
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "content": message.content or "",
+                        "tool_calls": [
+                            {
+                                "id": tool_call.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tool_call.function.name,
+                                    "arguments": tool_call.function.arguments,
+                                },
+                            }
+                            for tool_call in tool_calls
+                        ],
+                    }
                 )
-
-            message = response.choices[0].message
-
-            # If the model requested a tool, execute it (RAG path)
-            tool_calls = getattr(message, "tool_calls", None)
-            if self.settings.enable_rag and tool_calls:
-                try:
-                    tool_call = tool_calls[0]
+                for tool_call in tool_calls:
                     fn_name = tool_call.function.name
-                    args_json = tool_call.function.arguments or "{}"
-                    args = json.loads(args_json)
+                    try:
+                        args = json.loads(tool_call.function.arguments or "{}")
+                    except json.JSONDecodeError:
+                        args = {}
                     tool_result = await self.process_function_call(fn_name, args)
-                    return tool_result
-                except Exception as e:
-                    logger.error(f"Tool call handling failed: {e}")
+                    evidence.append(f"[{fn_name}]\n{tool_result}")
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_call.id,
+                            "content": tool_result,
+                        }
+                    )
 
-            # Fall back to normal assistant content
-            ai_response = message.content.strip()
+            if not ai_response:
+                # Tool budget exhausted without a final answer: show the
+                # gathered evidence rather than nothing.
+                ai_response = (
+                    evidence[-1]
+                    if evidence
+                    else self._get_fallback_response(user_message)
+                )
+
+            # Verification pass: drop or hedge claims the evidence doesn't
+            # support (refuse > invent). Only runs when evidence was
+            # gathered - purely conversational replies skip it.
+            if evidence and self.settings.enable_claim_verification:
+                ai_response = await self._verify_answer(ai_response, evidence)
 
             logger.info(f"Generated AI response: {ai_response[:100]}...")
             return ai_response
@@ -672,6 +909,56 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                 logger.error(f"Error getting AI response: {error_message}")
 
             return self._get_fallback_response(user_message)
+
+    async def _verify_answer(self, draft: str, evidence: List[str]) -> str:
+        """Claim-verification pass: refuse > invent.
+
+        A second model call checks the draft against the gathered tool
+        evidence and rewrites it to keep only supported factual claims.
+        Fails open (returns the draft) if the check itself errors, so an
+        outage degrades to today's behavior rather than silence.
+        """
+        try:
+            evidence_text = "\n\n---\n\n".join(evidence)[:8000]
+            response = self.client.chat.completions.create(
+                model=self.model,
+                max_tokens=800,
+                temperature=0.0,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a strict fact-checker for a civic "
+                            "information service. You receive EVIDENCE "
+                            "(tool outputs from official city data) and a "
+                            "DRAFT answer. Rewrite the draft so that every "
+                            "specific factual claim - dollar amounts, vote "
+                            "outcomes, dates, ordinance numbers, names of "
+                            "actions taken - is supported by the evidence. "
+                            "Remove or clearly hedge unsupported claims. "
+                            "Keep supported content, citations, links, and "
+                            "the helpful tone unchanged. If the core answer "
+                            "is not supported by the evidence, reply that "
+                            "the indexed record does not answer the "
+                            "question and point to official sources "
+                            "(cityoftulsa.org, tulsacouncil.org). Output "
+                            "only the final answer text."
+                        ),
+                    },
+                    {
+                        "role": "user",
+                        "content": (
+                            f"EVIDENCE:\n{evidence_text}\n\n"
+                            f"DRAFT:\n{draft}"
+                        ),
+                    },
+                ],
+            )
+            verified = (response.choices[0].message.content or "").strip()
+            return verified or draft
+        except Exception as e:
+            logger.warning(f"Claim verification failed open: {e}")
+            return draft
 
     def _get_fallback_response(self, user_message: str) -> str:
         """Provide fallback responses when OpenAI is not available"""

--- a/backend/app/services/intent_router.py
+++ b/backend/app/services/intent_router.py
@@ -1,0 +1,172 @@
+"""Intent classification for civic queries.
+
+Residents, journalists, and organizers ask different kinds of questions
+of the same corpus. Routing intent up front lets the chatbot steer each
+kind to the right evidence: budget facts to the structured budget table,
+meeting outcomes to minutes with identity keys, contact questions to the
+district lookup — instead of one undifferentiated RAG pass.
+
+Deliberately rule-based: deterministic, testable, and free. An LLM
+fallback can be layered on later for ambiguous queries; the contract
+(Intent name + retrieval hints) stays the same.
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Intent:
+    name: str
+    # Retrieval hints consumed by the chatbot service
+    preferred_tool: Optional[str] = None
+    document_type_filter: Optional[str] = None
+    guidance: str = ""
+    matched_terms: List[str] = field(default_factory=list)
+
+
+# Ordered: first match wins. Patterns are matched case-insensitively
+# against the whole message.
+_RULES = [
+    (
+        "budget_fact",
+        [
+            r"\bbudget(ed)?\b",
+            r"\bspend(ing|s)?\b",
+            r"\bspent\b",
+            r"\ballocat\w+",
+            r"\bfund(ing|ed)?\b",
+            r"\$[\d,.]+",
+            r"\bmillion\b",
+            r"\bfiscal year\b",
+            r"\bfy\s?20\d\d\b",
+            r"\bhow much (does|did|is|will)\b",
+            r"\bcost(s)?\b",
+        ],
+        dict(
+            preferred_tool="lookup_budget_line",
+            document_type_filter="budget",
+            guidance=(
+                "This looks like a budget question. Use the "
+                "lookup_budget_line tool for any dollar figure; only cite "
+                "amounts the tool returns. If the tool has no matching "
+                "line, say the structured budget table doesn't cover it "
+                "and link to cityoftulsa.org/budget-documents."
+            ),
+        ),
+    ),
+    (
+        "meeting_outcome",
+        [
+            r"\bvote(d|s)?\b",
+            r"\bdecid\w+",
+            r"\bpass(ed|es)?\b",
+            r"\bapprov\w+",
+            r"\bdenied\b",
+            r"\brejected\b",
+            r"\boutcome\b",
+            r"\bminutes\b",
+            r"\bagenda item\b",
+            r"\bresolution\b",
+            r"\bordinance\b",
+            r"\brezon\w+",
+        ],
+        dict(
+            preferred_tool="search_documents",
+            document_type_filter="meeting_minutes",
+            guidance=(
+                "This asks what Council actually did. Search meeting "
+                "minutes/agendas and cite the specific item; use "
+                "get_agenda_item when an item is identified. Label what "
+                "Council decided as distinct from what anyone proposed or "
+                "claimed. If the corpus has no record, say so."
+            ),
+        ),
+    ),
+    (
+        "contact_rep",
+        [
+            r"\bcouncilor\b",
+            r"\bcouncil member\b",
+            r"\brepresentative\b",
+            r"\bwho represents\b",
+            r"\bmy district\b",
+            r"\bcontact\b.*\b(council|mayor|city)\b",
+            r"\bemail\b.*\b(council|councilor|representative|mayor)\b",
+            r"\bwrite to\b",
+        ],
+        dict(
+            guidance=(
+                "This is about reaching a representative. Point to the "
+                "district lookup on the Contact Representatives page; "
+                "drafted emails are always reviewed and sent by the user, "
+                "never sent automatically."
+            ),
+        ),
+    ),
+    (
+        "subscribe_topic",
+        [
+            r"\bnotif\w+",
+            r"\balert(s)?\b",
+            r"\bsubscribe\b",
+            r"\bremind\w*",
+            r"\bkeep me (posted|updated|informed)\b",
+            r"\bsign up\b",
+        ],
+        dict(
+            guidance=(
+                "This is about notifications. Explain topic subscriptions "
+                "(SMS/email) and link to the notification signup; "
+                "subscriptions are opt-in with one-click unsubscribe."
+            ),
+        ),
+    ),
+    (
+        "process_how_to",
+        [
+            r"\bhow do i\b",
+            r"\bhow can i\b",
+            r"\bpermit(s)?\b",
+            r"\bapply(ing)?\b",
+            r"\bpublic comment\b",
+            r"\bspeak at\b",
+            r"\breport (a|an)\b",
+            r"\bpothole\b",
+            r"\b311\b",
+        ],
+        dict(
+            preferred_tool="search_documents",
+            guidance=(
+                "This is a how-to question about a civic process. Give "
+                "concrete steps with official links and contacts; search "
+                "documents for policy specifics rather than guessing."
+            ),
+        ),
+    ),
+]
+
+
+def classify_intent(message: str) -> Intent:
+    """Classify a user message into a civic intent.
+
+    The intent with the most matching patterns wins; ties break by rule
+    order ("How do I sign up for public comment?" matches one
+    subscribe_topic pattern but two process_how_to patterns, and should
+    route to the how-to answer).
+    """
+    lowered = message.lower()
+    best: Optional[Intent] = None
+    best_count = 0
+    for name, patterns, hints in _RULES:
+        matched = [p for p in patterns if re.search(p, lowered)]
+        if len(matched) > best_count:
+            best = Intent(name=name, matched_terms=matched, **hints)
+            best_count = len(matched)
+    return best if best is not None else Intent(name="general")
+
+
+def intents_summary() -> Dict[str, int]:
+    """Rule counts per intent (for status/debug endpoints)"""
+    return {name: len(patterns) for name, patterns, _ in _RULES}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,6 +82,32 @@ corpus (the pgvector column is sized from config on fresh databases).
   journalists and organizers, extends this corpus without changing the
   harness.
 
+## Grounded Q&A (Iteration 2)
+
+- **Intent routing** (`app/services/intent_router.py`): deterministic
+  best-match classification (budget_fact, meeting_outcome, contact_rep,
+  subscribe_topic, process_how_to) steers each query to the right evidence
+  before any model call.
+- **Numbers from table cells**: the `budget_lines` table (admin CSV import,
+  `/api/v1/budget/*`) is the only source the chatbot may cite dollar figures
+  from, via the `lookup_budget_line` tool — every row keeps its source
+  document/page. No matching row → the tool says "do not guess" and links
+  the official budget documents.
+- **Multi-tool agent loop**: tool results (document search, budget lookup,
+  `get_agenda_item`, `search_meetings`) are fed back to the model, which
+  synthesizes a cited answer — no more raw tool dumps as responses.
+- **Claim verification** (`ENABLE_CLAIM_VERIFICATION`, on by default): a
+  second, temperature-0 pass checks the draft against the gathered evidence
+  and removes or hedges unsupported claims; if the core answer is
+  unsupported, it refuses and points to official sources. Fails open on
+  errors.
+- **Contested-issue policy** (in the system prompt): no soft-pedaling or
+  evasion on housing, policing, budgets, or accountability — present what
+  Council actually did (cited) as distinct from claims about it, surface
+  staff reports and public comment where indexed, and disclose one-sided
+  corpus coverage. The platform serves residents' right to know, not the
+  city's narrative.
+
 ## Schema setup
 
 Fresh databases bootstrap via `create_tables()` (SQLAlchemy `create_all`) at
@@ -97,7 +123,7 @@ limitation inherited from the PoC.)
 | Iteration | Scope | Status |
 |---|---|---|
 | 1 — Evidence layer | provenance, hybrid index, item-level parsing, deep links | **shipped** on this branch (vendor-adapter hardening for TGOV/Granicus feeds remains ongoing) |
-| 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | eval harness seeded (`test_retrieval_eval.py`); the rest specced in the design sketch |
+| 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | **largely shipped**: intent router, budget tools, agent loop, claim verification, contested-issue policy, eval harness seed. Remaining: cross-encoder rerank, gold set expansion from research-day transcripts |
 | 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | PoC subscriptions exist; precision work pending |
 | 4 — Matters graph | track legislative matters across meetings; optional media | not started |
 

--- a/tests/backend/test_budget_tools.py
+++ b/tests/backend/test_budget_tools.py
@@ -1,0 +1,165 @@
+"""Tests for structured budget data and the grounded chatbot tools.
+
+Numbers come from table cells, never from prose: these tests pin the
+behavior of the CSV import, the lookup used by the lookup_budget_line
+tool, and the agenda-item/meeting tools the agent loop calls.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings  # noqa: E402
+from app.core.database import Base  # noqa: E402
+from app.models.budget import BudgetLine  # noqa: E402
+from app.models.meeting import AgendaItem, Meeting  # noqa: E402
+from app.services.budget_service import (  # noqa: E402
+    format_budget_lines,
+    import_budget_csv,
+    lookup_budget_lines,
+)
+from app.services.chatbot_service import ChatbotService  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+CSV_SAMPLE = """fiscal_year,fund,department,category,description,amount,source_url,page
+FY2026,General Fund,Police,Personnel,Sworn officer salaries,"240,000,000",https://cityoftulsa.org/budget,12
+FY2026,General Fund,Parks,Operations,Park maintenance,45000000,https://cityoftulsa.org/budget,31
+FY2026,General Fund,Parks,Capital,Trail improvements,$5000000,,
+FY2025,General Fund,Police,Personnel,Sworn officer salaries,232000000,,
+"""
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def test_csv_import_parses_amount_formats(db_session):
+    result = import_budget_csv(db_session, CSV_SAMPLE)
+    assert result["imported"] == 4
+    assert result["skipped"] == 0
+
+    police = lookup_budget_lines(db_session, fiscal_year="FY2026", department="Police")
+    assert len(police) == 1
+    assert float(police[0].amount) == 240_000_000.0
+
+
+def test_csv_import_rejects_missing_columns(db_session):
+    result = import_budget_csv(db_session, "department,amount\nPolice,100\n")
+    assert result["imported"] == 0
+    assert any("fiscal_year" in error for error in result["errors"])
+
+
+def test_csv_import_skips_bad_rows_and_reports(db_session):
+    csv_text = (
+        "fiscal_year,department,amount\n"
+        "FY2026,Parks,1000\n"
+        "FY2026,Police,not-a-number\n"
+    )
+    result = import_budget_csv(db_session, csv_text)
+    assert result["imported"] == 1
+    assert result["skipped"] == 1
+    assert result["errors"]
+
+
+def test_lookup_filters_by_keyword(db_session):
+    import_budget_csv(db_session, CSV_SAMPLE)
+    trails = lookup_budget_lines(db_session, keyword="trail")
+    assert len(trails) == 1
+    assert trails[0].category == "Capital"
+
+
+def test_format_includes_provenance_and_exact_amounts(db_session):
+    import_budget_csv(db_session, CSV_SAMPLE)
+    lines = lookup_budget_lines(db_session, fiscal_year="FY2026", department="Police")
+    formatted = format_budget_lines(lines)
+    assert "$240,000,000.00" in formatted
+    assert "cityoftulsa.org/budget" in formatted
+    assert "p.12" in formatted
+
+
+def test_format_refuses_when_empty():
+    formatted = format_budget_lines([])
+    assert "Do not guess" in formatted
+
+
+@pytest.fixture
+def chatbot(db_session):
+    return ChatbotService(db_session, Settings())
+
+
+@pytest.mark.asyncio
+async def test_lookup_budget_line_tool(db_session, chatbot):
+    import_budget_csv(db_session, CSV_SAMPLE)
+    result = await chatbot.process_function_call(
+        "lookup_budget_line", {"department": "Parks", "fiscal_year": "FY2026"}
+    )
+    assert "$45,000,000.00" in result
+    assert "cite these figures exactly" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_get_agenda_item_tool(db_session, chatbot):
+    meeting = Meeting(
+        id=1,
+        title="Regular Council Meeting",
+        meeting_type="city_council",
+        meeting_date=datetime(2025, 6, 4, 17, 0),
+        source="test",
+    )
+    db_session.add(meeting)
+    db_session.add(
+        AgendaItem(
+            id=10,
+            meeting_id=1,
+            item_number="2.A",
+            title="Rezoning at 4501 S Peoria",
+            vote_result="passed",
+        )
+    )
+    db_session.commit()
+
+    result = await chatbot.process_function_call(
+        "get_agenda_item", {"meeting_id": 1, "item_number": "2.a"}
+    )
+    assert "Rezoning at 4501 S Peoria" in result
+    assert "passed" in result
+    assert "/meetings?meeting=1" in result
+
+
+@pytest.mark.asyncio
+async def test_get_agenda_item_refuses_on_unknown(db_session, chatbot):
+    result = await chatbot.process_function_call(
+        "get_agenda_item", {"meeting_id": 99, "item_number": "1"}
+    )
+    assert "Do not guess" in result
+
+
+@pytest.mark.asyncio
+async def test_search_meetings_tool(db_session, chatbot):
+    db_session.add(
+        Meeting(
+            id=2,
+            title="Public Hearing on Housing",
+            meeting_type="public_hearing",
+            meeting_date=datetime(2025, 5, 1, 17, 0),
+            source="test",
+        )
+    )
+    db_session.commit()
+
+    result = await chatbot.process_function_call(
+        "search_meetings", {"topic": "housing"}
+    )
+    assert "Public Hearing on Housing" in result
+    assert "/meetings?meeting=2" in result

--- a/tests/backend/test_intent_router.py
+++ b/tests/backend/test_intent_router.py
@@ -1,0 +1,52 @@
+"""Tests for the civic-query intent router."""
+
+import sys
+from pathlib import Path
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.services.intent_router import classify_intent  # noqa: E402
+
+
+def test_budget_questions_route_to_budget_tool():
+    for message in [
+        "How much does Tulsa spend on parks?",
+        "What's the police budget for FY2026?",
+        "How is the $1.1 billion allocated?",
+    ]:
+        intent = classify_intent(message)
+        assert intent.name == "budget_fact", message
+        assert intent.preferred_tool == "lookup_budget_line"
+
+
+def test_outcome_questions_route_to_minutes():
+    for message in [
+        "Did the council approve the rezoning at 41st and Peoria?",
+        "What was the vote on the curfew ordinance?",
+        "What did council decide about agenda item 2.a?",
+    ]:
+        intent = classify_intent(message)
+        assert intent.name == "meeting_outcome", message
+        assert intent.document_type_filter == "meeting_minutes"
+
+
+def test_contact_questions():
+    intent = classify_intent("Who represents my district and how do I contact them?")
+    assert intent.name == "contact_rep"
+
+
+def test_subscription_questions():
+    intent = classify_intent("Can you send me alerts about housing meetings?")
+    assert intent.name == "subscribe_topic"
+
+
+def test_how_to_questions():
+    intent = classify_intent("How do I sign up for public comment at a meeting?")
+    assert intent.name in ("process_how_to", "meeting_outcome")
+
+
+def test_general_fallback():
+    intent = classify_intent("Tell me about the Gathering Place")
+    assert intent.name == "general"
+    assert intent.guidance == ""


### PR DESCRIPTION
Implements Iteration 2 of the design sketch: cite-then-verify answers, numbers from structured tables, refuse rather than invent.

## Changes

- **Structured budget data** (the GRASP lesson): `budget_lines` table with per-row source document/page/URL, admin CSV import with row-level error reporting, public `/api/v1/budget/*` query API — the chatbot's `lookup_budget_line` tool is the only permitted source for dollar figures, and it answers "do not guess" with a link to official budget documents when no row matches
- **Intent router**: deterministic best-match classification (`budget_fact`, `meeting_outcome`, `contact_rep`, `subscribe_topic`, `process_how_to`) injects per-intent guidance before any model call
- **Multi-tool agent loop**: tool results (document search, budget lookup, new `get_agenda_item` and `search_meetings` tools with deep links) feed back into the model for a synthesized, cited answer — previously the raw tool dump WAS the answer
- **Claim verification** (`ENABLE_CLAIM_VERIFICATION`, default on): temperature-0 second pass drops/hedges claims the evidence doesn't support; unsupported core answers become refusals pointing to official sources; fails open on provider outage
- **Contested-issue policy** in the system prompt: cite what Council did, distinguish it from claims about it, disclose one-sided corpus coverage — no evasion on housing, policing, budgets, or accountability

## Verification

Full backend suite (50 tests) passes: CSV import edge cases, budget/agenda-item/meeting tools, intent routing, and the retrieval gold set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_