### PR TITLE
CI: fix the two failing Test and Code Quality jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 
@@ -117,10 +117,14 @@ jobs:
         cd frontend
         npm run build
 
-    - name: Check bundle size
+    # Bundle sizes are reported from the build output; the previous
+    # `npm run analyze` step ran an unpinned `npx vite-bundle-analyzer`,
+    # whose latest release is ESM-only and crashes CI.
+    - name: Report bundle size
       run: |
         cd frontend
-        npm run analyze
+        du -sh dist
+        ls -lS dist/assets | head -20
 
   security-scan:
     name: Security Scan
@@ -136,8 +140,11 @@ jobs:
     - name: Prepare SARIF output dir
       run: mkdir -p reports
 
+    # Pinned tags of trivy-action have been removed upstream before
+    # (0.28.0 became unresolvable and failed every run); master is the
+    # maintained ref the project documents.
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@0.28.0
+      uses: aquasecurity/trivy-action@master
       with:
         scan-type: 'fs'
         scan-ref: '.'


### PR DESCRIPTION
Every recent PR and push to main showed a red "Test and Code Quality" check. The Backend Tests job passed every time — two auxiliary jobs were broken by stale pins that predate the platform migration:

## Changes

- **Frontend job**: the final "Check bundle size" step ran an unpinned `npx vite-bundle-analyzer`; its latest release is ESM-only and crashes Node 18 with `ERR_REQUIRE_ESM`. Replaced with a bundle-size report from the build output (`du`/`ls` on `dist/`), and the job now runs Node 20.
- **Security-scan job**: `aquasecurity/trivy-action@0.28.0` no longer resolves upstream (the tag was removed), failing before any scan ran. Now uses the maintained `master` ref, per the project's own documentation.

## Verification

Lint, type-check, tests, and build already pass locally and in CI; this only removes/repins the two steps that fail independent of code. The merge run of this PR should be the first fully green "Test and Code Quality" on main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_