### PR TITLE
Iteration 3: watches and outreach that earn trust

### DIFF
--- a/backend/alembic/versions/010_add_chat_feedback.py
+++ b/backend/alembic/versions/010_add_chat_feedback.py
@@ -1,0 +1,44 @@
+"""Add chat_feedback table (feedback review queue)
+
+Every negative signal triggers manual review; the queue is the roadmap.
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "010"
+down_revision = "009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_feedback",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("rating", sa.String(10), nullable=False, index=True),
+        sa.Column("question", sa.Text(), nullable=False),
+        sa.Column("answer", sa.Text(), nullable=False),
+        sa.Column("comment", sa.Text()),
+        sa.Column("intent", sa.String(50)),
+        sa.Column(
+            "reviewed", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("resolution", sa.Text()),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True)),
+    )
+    op.create_index("ix_chat_feedback_reviewed", "chat_feedback", ["reviewed"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chat_feedback_reviewed", table_name="chat_feedback")
+    op.drop_table("chat_feedback")

--- a/backend/app/api/v1/endpoints/chatbot.py
+++ b/backend/app/api/v1/endpoints/chatbot.py
@@ -1,10 +1,15 @@
-from typing import List, Optional
+from datetime import datetime, timezone
+from typing import List, Literal, Optional
 
 from app.core.config import Settings, get_settings
 from app.core.database import get_db
+from app.models.feedback import ChatFeedback
+from app.models.user import User
+from app.services.auth import get_current_admin_user
 from app.services.chatbot_service import ChatbotService
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from app.services.intent_router import classify_intent
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 router = APIRouter()
@@ -24,6 +29,17 @@ class ChatResponse(BaseModel):
     response: str
     success: bool
     error: Optional[str] = None
+
+
+class FeedbackRequest(BaseModel):
+    rating: Literal["up", "down"]
+    question: str = Field(min_length=1, max_length=4000)
+    answer: str = Field(min_length=1, max_length=16000)
+    comment: Optional[str] = Field(None, max_length=2000)
+
+
+class FeedbackReviewRequest(BaseModel):
+    resolution: Optional[str] = Field(None, max_length=4000)
 
 
 @router.get("/status")
@@ -80,3 +96,77 @@ async def chat_with_ai(
             success=False,
             error=str(e),
         )
+
+
+@router.post("/feedback")
+async def submit_feedback(
+    request: FeedbackRequest,
+    db: Session = Depends(get_db),
+):
+    """Record resident feedback on a chatbot answer.
+
+    Thumbs-downs land in a review queue that is worked weekly: each miss
+    becomes a corpus, prompt, or tool fix. Feedback is anonymous.
+    """
+    feedback = ChatFeedback(
+        rating=request.rating,
+        question=request.question,
+        answer=request.answer,
+        comment=request.comment,
+        intent=classify_intent(request.question).name,
+    )
+    db.add(feedback)
+    db.commit()
+    return {"message": "Thanks — your feedback improves the service.", "id": feedback.id}
+
+
+@router.get("/feedback")
+async def list_feedback(
+    reviewed: Optional[bool] = Query(False, description="Filter by review state"),
+    rating: Optional[str] = Query(None, pattern="^(up|down)$"),
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user),
+):
+    """The review queue (admin): unreviewed thumbs-downs are the backlog"""
+    query = db.query(ChatFeedback)
+    if reviewed is not None:
+        query = query.filter(ChatFeedback.reviewed == reviewed)
+    if rating:
+        query = query.filter(ChatFeedback.rating == rating)
+    items = query.order_by(ChatFeedback.created_at.desc()).limit(limit).all()
+    return {
+        "feedback": [
+            {
+                "id": item.id,
+                "rating": item.rating,
+                "question": item.question,
+                "answer": item.answer[:1000],
+                "comment": item.comment,
+                "intent": item.intent,
+                "reviewed": item.reviewed,
+                "created_at": item.created_at,
+            }
+            for item in items
+        ],
+        "total": len(items),
+    }
+
+
+@router.post("/feedback/{feedback_id}/review")
+async def review_feedback(
+    feedback_id: int,
+    request: FeedbackReviewRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user),
+):
+    """Mark a feedback item reviewed, recording what was done about it"""
+    feedback = db.query(ChatFeedback).filter(ChatFeedback.id == feedback_id).first()
+    if not feedback:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+
+    feedback.reviewed = True
+    feedback.resolution = request.resolution
+    feedback.reviewed_at = datetime.now(timezone.utc)
+    db.commit()
+    return {"message": "Feedback marked reviewed", "id": feedback.id}

--- a/backend/app/api/v1/endpoints/subscriptions.py
+++ b/backend/app/api/v1/endpoints/subscriptions.py
@@ -2,8 +2,9 @@ import secrets
 from datetime import datetime, timedelta
 from typing import List
 
-from app.core.config import get_settings
+from app.core.config import Settings, get_settings
 from app.core.database import get_db
+from app.core.tokens import verify_unsubscribe_token
 from app.models.notification_preferences import NotificationPreferences
 from app.models.subscription import MeetingTopic, TopicSubscription
 from app.schemas.notification_preferences import (
@@ -251,9 +252,59 @@ async def confirm_subscription(
     }
 
 
+def _deactivate_subscription(db: Session, subscription: TopicSubscription) -> None:
+    subscription.is_active = False
+    subscription.updated_at = datetime.utcnow()
+
+    # Update subscriber counts for topics
+    for topic_name in subscription.interested_topics or []:
+        topic = db.query(MeetingTopic).filter(MeetingTopic.name == topic_name).first()
+        if topic and topic.subscriber_count > 0:
+            topic.subscriber_count -= 1
+
+    db.commit()
+
+
+@router.get("/unsubscribe")
+async def unsubscribe_by_token(
+    token: str,
+    db: Session = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    """One-click unsubscribe from a notification link.
+
+    The signed token identifies the subscription without exposing
+    enumerable IDs and works from an email or SMS without login.
+    """
+    subscription_id = verify_unsubscribe_token(settings, token)
+    if subscription_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid or expired unsubscribe link",
+        )
+
+    subscription = (
+        db.query(TopicSubscription)
+        .filter(TopicSubscription.id == subscription_id)
+        .first()
+    )
+    if not subscription:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Subscription not found"
+        )
+
+    if subscription.is_active:
+        _deactivate_subscription(db, subscription)
+
+    return {
+        "message": "You have been unsubscribed from meeting notifications.",
+        "resubscribe": "/signup/notifications",
+    }
+
+
 @router.delete("/unsubscribe/{subscription_id}")
 async def unsubscribe(subscription_id: int, db: Session = Depends(get_db)):
-    """Unsubscribe from notifications"""
+    """Unsubscribe from notifications (authenticated app flow)"""
 
     subscription = (
         db.query(TopicSubscription)
@@ -266,16 +317,7 @@ async def unsubscribe(subscription_id: int, db: Session = Depends(get_db)):
             status_code=status.HTTP_404_NOT_FOUND, detail="Subscription not found"
         )
 
-    subscription.is_active = False
-    subscription.updated_at = datetime.utcnow()
-
-    # Update subscriber counts for topics
-    for topic_name in subscription.interested_topics or []:
-        topic = db.query(MeetingTopic).filter(MeetingTopic.name == topic_name).first()
-        if topic and topic.subscriber_count > 0:
-            topic.subscriber_count -= 1
-
-    db.commit()
+    _deactivate_subscription(db, subscription)
 
     return {"message": "Successfully unsubscribed"}
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -90,6 +90,10 @@ class Settings(BaseSettings):
     # Comma-separated list, e.g. "https://civicspark.vercel.app,https://civicspark.org"
     cors_origins: str = ""
 
+    # Public frontend origin, used to build absolute deep links in
+    # notifications (e.g. https://civicspark.vercel.app). Empty = relative.
+    frontend_url: str = ""
+
     # RAG Configuration
     enable_rag: bool = True
     # Second-pass claim verification on tool-grounded answers (refuse > invent)

--- a/backend/app/core/tokens.py
+++ b/backend/app/core/tokens.py
@@ -1,0 +1,49 @@
+"""Signed, expiring tokens for one-click actions in notifications.
+
+Unsubscribe links must work from an email or SMS with a single click —
+no login, no enumerable IDs. Tokens are HMAC-SHA256 signed with the app
+secret; no extra dependency needed.
+"""
+
+import base64
+import hashlib
+import hmac
+import time
+from typing import Optional
+
+from app.core.config import Settings
+
+UNSUBSCRIBE_MAX_AGE_SECONDS = 60 * 60 * 24 * 180  # 180 days
+
+
+def _sign(settings: Settings, payload: str) -> str:
+    digest = hmac.new(
+        settings.secret_key.encode(), payload.encode(), hashlib.sha256
+    ).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def make_unsubscribe_token(settings: Settings, subscription_id: int) -> str:
+    """Create a signed unsubscribe token for a subscription"""
+    payload = f"unsub.{subscription_id}.{int(time.time())}"
+    signature = _sign(settings, payload)
+    raw = f"{payload}.{signature}"
+    return base64.urlsafe_b64encode(raw.encode()).decode().rstrip("=")
+
+
+def verify_unsubscribe_token(settings: Settings, token: str) -> Optional[int]:
+    """Return the subscription id for a valid token, else None"""
+    try:
+        padded = token + "=" * (-len(token) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        action, sub_id, issued_at, signature = raw.rsplit(".", 3)[-4:]
+        payload = f"{action}.{sub_id}.{issued_at}"
+        if action != "unsub":
+            return None
+        if not hmac.compare_digest(signature, _sign(settings, payload)):
+            return None
+        if time.time() - int(issued_at) > UNSUBSCRIBE_MAX_AGE_SECONDS:
+            return None
+        return int(sub_id)
+    except Exception:
+        return None

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from .document import (
     DocumentCollection,
     DocumentCollectionMembership,
 )
+from .feedback import ChatFeedback
 from .meeting import AgendaItem, Meeting, MeetingCategory
 from .notification import Notification, NotificationPreference, NotificationTemplate
 from .notification_preferences import NotificationPreferences
@@ -20,6 +21,7 @@ from .user import User, UserInterests
 
 __all__ = [
     "BudgetLine",
+    "ChatFeedback",
     "User",
     "UserInterests",
     "Meeting",

--- a/backend/app/models/feedback.py
+++ b/backend/app/models/feedback.py
@@ -1,0 +1,33 @@
+from app.core.database import Base
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Text
+from sqlalchemy.sql import func
+
+
+class ChatFeedback(Base):
+    """Resident feedback on chatbot answers.
+
+    Every thumbs-down is a work item, not a metric: the review queue is
+    the product backlog (wrong answer → corpus or prompt fix; missing
+    doc → ingest task). Kept PII-light: no user account linkage, just
+    the exchange and optional comment.
+    """
+
+    __tablename__ = "chat_feedback"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    rating = Column(String(10), nullable=False, index=True)  # "up" | "down"
+    question = Column(Text, nullable=False)
+    answer = Column(Text, nullable=False)
+    comment = Column(Text)  # optional free-text from the user
+    intent = Column(String(50))  # routed intent, for triage patterns
+
+    # Review workflow
+    reviewed = Column(Boolean, default=False, nullable=False, index=True)
+    resolution = Column(Text)  # what was fixed / why it was fine
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    reviewed_at = Column(DateTime(timezone=True))
+
+    def __repr__(self):
+        return f"<ChatFeedback({self.rating}, reviewed={self.reviewed})>"

--- a/backend/app/services/meeting_upsert_service.py
+++ b/backend/app/services/meeting_upsert_service.py
@@ -101,6 +101,18 @@ class MeetingUpsertService:
             # Create/recreate agenda items
             MeetingUpsertService._create_agenda_items(db, meeting.id, processed_content)
 
+            # Ingest-time watch matching: queue deep-link-first alerts for
+            # subscribers the moment a meeting lands, instead of waiting
+            # for the nightly poll. Never allowed to break ingestion.
+            if is_new:
+                try:
+                    from app.core.config import settings
+                    from app.services.watch_service import WatchService
+
+                    WatchService(settings).queue_matches(db, meeting)
+                except Exception as e:
+                    logger.warning(f"Watch matching failed for {external_id}: {e}")
+
             return meeting, is_new
 
         except IntegrityError as e:

--- a/backend/app/services/watch_service.py
+++ b/backend/app/services/watch_service.py
@@ -1,0 +1,231 @@
+"""Ingest-time topic-watch matching.
+
+Subscriptions are a retrieval job that runs when new meetings are
+ingested — not a chatbot feature and not only a nightly poll. Matching is
+dual-track (keyword ∪ topic label, per Engagic's lesson): an item-level
+keyword hit outranks a topic-label hit, which outranks a bare
+meeting-type hit. Every notification carries a deep link to the meeting
+record; a summary is optional extra, never the only content.
+
+Matching runs in Python over the subscription rows (a few thousand at
+most), which keeps it portable across Postgres and SQLite instead of
+depending on jsonb operators.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from app.core.config import Settings
+from app.core.tokens import make_unsubscribe_token
+from app.models.meeting import AgendaItem, Meeting
+from app.models.subscription import MeetingTopic, NotificationLog, TopicSubscription
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# Specificity tiers, strongest first.
+SPECIFICITY_ITEM_KEYWORD = "item_keyword"
+SPECIFICITY_TOPIC = "topic"
+SPECIFICITY_MEETING_TYPE = "meeting_type"
+
+_SPECIFICITY_ORDER = {
+    SPECIFICITY_ITEM_KEYWORD: 0,
+    SPECIFICITY_TOPIC: 1,
+    SPECIFICITY_MEETING_TYPE: 2,
+}
+
+
+@dataclass
+class WatchMatch:
+    """One subscription matched against one ingested meeting"""
+
+    subscription: TopicSubscription
+    meeting: Meeting
+    specificity: str
+    matched_topics: List[str] = field(default_factory=list)
+    # (keyword, agenda item title) pairs for item-level hits
+    matched_items: List[tuple] = field(default_factory=list)
+
+    @property
+    def rank(self) -> int:
+        return _SPECIFICITY_ORDER[self.specificity]
+
+
+class WatchService:
+    """Match ingested meetings against active topic watches and queue
+    deep-link-first notifications."""
+
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def match_meeting(self, db: Session, meeting: Meeting) -> List[WatchMatch]:
+        """Match one meeting against all active, confirmed subscriptions.
+
+        Returns matches sorted strongest-specificity first.
+        """
+        subscriptions = (
+            db.query(TopicSubscription)
+            .filter(
+                TopicSubscription.is_active.is_(True),
+                TopicSubscription.confirmed.is_(True),
+            )
+            .all()
+        )
+        if not subscriptions:
+            return []
+
+        agenda_items = (
+            db.query(AgendaItem).filter(AgendaItem.meeting_id == meeting.id).all()
+        )
+        topic_keywords = self._topic_keywords(db)
+        meeting_topics = {t.lower() for t in (meeting.topics or [])}
+
+        matches: List[WatchMatch] = []
+        for subscription in subscriptions:
+            match = self._match_subscription(
+                subscription, meeting, meeting_topics, agenda_items, topic_keywords
+            )
+            if match is not None:
+                matches.append(match)
+
+        matches.sort(key=lambda m: m.rank)
+        return matches
+
+    def _topic_keywords(self, db: Session) -> dict:
+        """topic name (lower) -> list of match keywords (lower)"""
+        keywords = {}
+        for topic in db.query(MeetingTopic).filter(MeetingTopic.is_active.is_(True)):
+            words = [k.lower() for k in (topic.keywords or []) if k]
+            words.append(topic.name.lower())
+            if topic.display_name:
+                words.append(topic.display_name.lower())
+            keywords[topic.name.lower()] = words
+        return keywords
+
+    def _match_subscription(
+        self,
+        subscription: TopicSubscription,
+        meeting: Meeting,
+        meeting_topics: set,
+        agenda_items: List[AgendaItem],
+        topic_keywords: dict,
+    ) -> Optional[WatchMatch]:
+        interested = [t.lower() for t in (subscription.interested_topics or [])]
+
+        # Track 1 (strongest): subscriber's topic keywords appear in a
+        # specific agenda item's title/description.
+        matched_items = []
+        for topic in interested:
+            for keyword in topic_keywords.get(topic, [topic]):
+                for item in agenda_items:
+                    haystack = f"{item.title or ''} {item.description or ''}".lower()
+                    if keyword and keyword in haystack:
+                        matched_items.append((keyword, item.title or ""))
+        if matched_items:
+            return WatchMatch(
+                subscription=subscription,
+                meeting=meeting,
+                specificity=SPECIFICITY_ITEM_KEYWORD,
+                matched_topics=sorted({keyword for keyword, _ in matched_items}),
+                matched_items=matched_items[:5],
+            )
+
+        # Track 2: topic-label intersection with the meeting's AI topics.
+        matched_topics = sorted(meeting_topics.intersection(interested))
+        if matched_topics:
+            return WatchMatch(
+                subscription=subscription,
+                meeting=meeting,
+                specificity=SPECIFICITY_TOPIC,
+                matched_topics=matched_topics,
+            )
+
+        # Track 3 (weakest): bare meeting-type interest.
+        meeting_types = [t.lower() for t in (subscription.meeting_types or [])]
+        if meeting.meeting_type and meeting.meeting_type.lower() in meeting_types:
+            return WatchMatch(
+                subscription=subscription,
+                meeting=meeting,
+                specificity=SPECIFICITY_MEETING_TYPE,
+            )
+
+        return None
+
+    def queue_matches(self, db: Session, meeting: Meeting) -> int:
+        """Queue notifications for a newly ingested meeting.
+
+        Creates NotificationLog rows with status 'queued'; actual delivery
+        (immediate vs digest, quiet hours, per-day caps) is decided at
+        dispatch time. Deduplicates against anything already logged for
+        this (subscription, meeting) pair. Returns the number queued.
+        """
+        queued = 0
+        for match in self.match_meeting(db, meeting):
+            if self._already_logged(db, match.subscription.id, meeting.id):
+                continue
+
+            message = self.render_message(match)
+            channels = []
+            if match.subscription.sms_notifications and match.subscription.phone_number:
+                channels.append("sms")
+            if match.subscription.email_notifications and match.subscription.email:
+                channels.append("email")
+
+            for channel in channels:
+                db.add(
+                    NotificationLog(
+                        subscription_id=match.subscription.id,
+                        meeting_id=meeting.id,
+                        subject=f"New match: {meeting.title}"[:250],
+                        message=message,
+                        notification_type=channel,
+                        delivery_status="queued",
+                    )
+                )
+                queued += 1
+
+        if queued:
+            db.flush()
+            logger.info(
+                f"Queued {queued} watch notifications for meeting {meeting.id}"
+            )
+        return queued
+
+    def render_message(self, match: WatchMatch) -> str:
+        """Deep link first; matched items next; summary is optional extra"""
+        meeting = match.meeting
+        base = self.settings.frontend_url.rstrip("/")
+        deep_link = f"{base}/meetings?meeting={meeting.id}"
+        unsubscribe = (
+            f"{base}/api/v1/subscriptions/unsubscribe"
+            f"?token={make_unsubscribe_token(self.settings, match.subscription.id)}"
+        )
+
+        lines = [
+            f"{meeting.title} — "
+            f"{meeting.meeting_date.strftime('%b %d, %I:%M %p')}",
+            f"View the agenda: {deep_link}",
+        ]
+        if match.matched_items:
+            for keyword, title in match.matched_items[:3]:
+                lines.append(f'• Item matching "{keyword}": {title[:80]}')
+        elif match.matched_topics:
+            lines.append(f"Topics you watch: {', '.join(match.matched_topics[:5])}")
+        if meeting.summary:
+            lines.append(meeting.summary[:160])
+        lines.append(f"Unsubscribe: {unsubscribe}")
+        return "\n".join(lines)
+
+    def _already_logged(
+        self, db: Session, subscription_id: int, meeting_id: int
+    ) -> bool:
+        return (
+            db.query(NotificationLog)
+            .filter(
+                NotificationLog.subscription_id == subscription_id,
+                NotificationLog.meeting_id == meeting_id,
+            )
+            .first()
+            is not None
+        )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,6 +108,26 @@ corpus (the pgvector column is sized from config on fresh databases).
   corpus coverage. The platform serves residents' right to know, not the
   city's narrative.
 
+## Watches & feedback (Iteration 3)
+
+- **Ingest-time matching** (`app/services/watch_service.py`): the moment a
+  new meeting is upserted, active confirmed subscriptions are matched
+  dual-track — item-level keyword hits outrank topic-label hits, which
+  outrank bare meeting-type interest — and notifications are queued per
+  channel with dedup. Matching never blocks ingestion.
+- **Deep link first**: every alert leads with the meeting deep link
+  (`/meetings?meeting=<id>`); matched item titles next; the AI summary is
+  optional extra, never the only content.
+- **Consent**: one-click unsubscribe via HMAC-signed expiring tokens
+  (`app/core/tokens.py`, `GET /subscriptions/unsubscribe?token=...`) in
+  every message — no login, no enumerable IDs. Quiet hours, digest mode,
+  and per-day caps live on the subscription and are honored at dispatch.
+  Zero auto-sends anywhere in the platform.
+- **Feedback review queue** (`chat_feedback`, `POST /chatbot/feedback`):
+  every thumbs-down is a work item tagged with its routed intent; the
+  admin queue (`GET /chatbot/feedback?reviewed=false`) is the product
+  backlog — each miss becomes a corpus, prompt, or tool fix.
+
 ## Schema setup
 
 Fresh databases bootstrap via `create_tables()` (SQLAlchemy `create_all`) at
@@ -124,7 +144,7 @@ limitation inherited from the PoC.)
 |---|---|---|
 | 1 — Evidence layer | provenance, hybrid index, item-level parsing, deep links | **shipped** on this branch (vendor-adapter hardening for TGOV/Granicus feeds remains ongoing) |
 | 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | **largely shipped**: intent router, budget tools, agent loop, claim verification, contested-issue policy, eval harness seed. Remaining: cross-encoder rerank, gold set expansion from research-day transcripts |
-| 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | PoC subscriptions exist; precision work pending |
+| 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | **largely shipped**: dual-track matching at ingest, deep-link-first messages, signed one-click unsubscribe, feedback review queue. Remaining: digest dispatch loop, alert-retention metrics |
 | 4 — Matters graph | track legislative matters across meetings; optional media | not started |
 
 The failure modes in the design sketch are the acceptance tests: if budget

--- a/tests/backend/test_tokens_and_feedback.py
+++ b/tests/backend/test_tokens_and_feedback.py
@@ -1,0 +1,70 @@
+"""Tests for one-click unsubscribe tokens and the feedback review queue."""
+
+import sys
+import time
+from pathlib import Path
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings  # noqa: E402
+from app.core.database import Base  # noqa: E402
+from app.core.tokens import (  # noqa: E402
+    make_unsubscribe_token,
+    verify_unsubscribe_token,
+)
+from app.models.feedback import ChatFeedback  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+SETTINGS = Settings()
+
+
+def test_unsubscribe_token_round_trip():
+    token = make_unsubscribe_token(SETTINGS, 42)
+    assert verify_unsubscribe_token(SETTINGS, token) == 42
+
+
+def test_tampered_token_rejected():
+    token = make_unsubscribe_token(SETTINGS, 42)
+    tampered = token[:-4] + ("AAAA" if not token.endswith("AAAA") else "BBBB")
+    assert verify_unsubscribe_token(SETTINGS, tampered) is None
+
+
+def test_token_bound_to_secret():
+    other = Settings(secret_key="a-completely-different-secret-key-value")
+    token = make_unsubscribe_token(SETTINGS, 42)
+    assert verify_unsubscribe_token(other, token) is None
+
+
+def test_garbage_token_rejected():
+    assert verify_unsubscribe_token(SETTINGS, "not-a-token") is None
+    assert verify_unsubscribe_token(SETTINGS, "") is None
+
+
+def test_expired_token_rejected(monkeypatch):
+    token = make_unsubscribe_token(SETTINGS, 7)
+    future = time.time() + 60 * 60 * 24 * 181  # past the 180-day window
+    monkeypatch.setattr("app.core.tokens.time.time", lambda: future)
+    assert verify_unsubscribe_token(SETTINGS, token) is None
+
+
+def test_feedback_rows_default_to_unreviewed():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+
+    session.add(
+        ChatFeedback(
+            rating="down",
+            question="How much does Tulsa spend on parks?",
+            answer="Some unsupported figure",
+            intent="budget_fact",
+        )
+    )
+    session.commit()
+
+    row = session.query(ChatFeedback).one()
+    assert row.reviewed is False
+    assert row.intent == "budget_fact"
+    session.close()

--- a/tests/backend/test_watch_service.py
+++ b/tests/backend/test_watch_service.py
@@ -1,0 +1,165 @@
+"""Tests for ingest-time watch matching and deep-link-first alerts."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings  # noqa: E402
+from app.core.database import Base  # noqa: E402
+from app.models.meeting import AgendaItem, Meeting  # noqa: E402
+from app.models.subscription import (  # noqa: E402
+    MeetingTopic,
+    NotificationLog,
+    TopicSubscription,
+)
+from app.services.watch_service import (  # noqa: E402
+    SPECIFICITY_ITEM_KEYWORD,
+    SPECIFICITY_MEETING_TYPE,
+    SPECIFICITY_TOPIC,
+    WatchService,
+)
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def service():
+    return WatchService(Settings())
+
+
+def _subscription(db, sub_id, topics=None, meeting_types=None, **overrides):
+    subscription = TopicSubscription(
+        id=sub_id,
+        email=f"resident{sub_id}@example.com",
+        full_name=f"Resident {sub_id}",
+        phone_number=f"+1918555{sub_id:04d}",
+        interested_topics=topics or [],
+        meeting_types=meeting_types or [],
+        is_active=overrides.pop("is_active", True),
+        confirmed=overrides.pop("confirmed", True),
+        sms_notifications=overrides.pop("sms_notifications", True),
+        email_notifications=overrides.pop("email_notifications", True),
+    )
+    db.add(subscription)
+    db.commit()
+    return subscription
+
+
+def _meeting(db, meeting_id=1, topics=None, meeting_type="city_council"):
+    meeting = Meeting(
+        id=meeting_id,
+        title="Regular Council Meeting",
+        meeting_type=meeting_type,
+        meeting_date=datetime(2026, 8, 5, 17, 0),
+        source="test",
+        topics=topics or [],
+        summary="Council considered several items.",
+    )
+    db.add(meeting)
+    db.commit()
+    return meeting
+
+
+def _topic(db, name, keywords):
+    db.add(MeetingTopic(name=name, display_name=name.title(), keywords=keywords))
+    db.commit()
+
+
+def test_item_keyword_match_outranks_topic_match(db, service):
+    _topic(db, "housing", ["rezoning", "affordable housing"])
+    _subscription(db, 1, topics=["housing"])
+    _subscription(db, 2, topics=["transportation"])
+
+    meeting = _meeting(db, topics=["transportation"])
+    db.add(
+        AgendaItem(
+            meeting_id=meeting.id,
+            item_number="2",
+            title="Rezoning application Z-7642 at 41st and Peoria",
+        )
+    )
+    db.commit()
+
+    matches = service.match_meeting(db, meeting)
+    assert [m.subscription.id for m in matches] == [1, 2]
+    assert matches[0].specificity == SPECIFICITY_ITEM_KEYWORD
+    assert matches[1].specificity == SPECIFICITY_TOPIC
+
+
+def test_meeting_type_is_weakest_match(db, service):
+    _subscription(db, 1, meeting_types=["city_council"])
+    meeting = _meeting(db)
+
+    matches = service.match_meeting(db, meeting)
+    assert len(matches) == 1
+    assert matches[0].specificity == SPECIFICITY_MEETING_TYPE
+
+
+def test_inactive_and_unconfirmed_subscribers_excluded(db, service):
+    _subscription(db, 1, topics=["housing"], is_active=False)
+    _subscription(db, 2, topics=["housing"], confirmed=False)
+    meeting = _meeting(db, topics=["housing"])
+
+    assert service.match_meeting(db, meeting) == []
+
+
+def test_queue_creates_logs_per_channel_and_dedupes(db, service):
+    _subscription(db, 1, topics=["housing"])
+    meeting = _meeting(db, topics=["housing"])
+
+    queued_first = service.queue_matches(db, meeting)
+    queued_second = service.queue_matches(db, meeting)
+
+    assert queued_first == 2  # sms + email
+    assert queued_second == 0  # deduplicated
+    logs = db.query(NotificationLog).all()
+    assert {log.notification_type for log in logs} == {"sms", "email"}
+    assert all(log.delivery_status == "queued" for log in logs)
+
+
+def test_message_is_deep_link_first_with_unsubscribe(db, service):
+    _topic(db, "housing", ["rezoning"])
+    subscription = _subscription(db, 1, topics=["housing"])
+    meeting = _meeting(db)
+    db.add(
+        AgendaItem(
+            meeting_id=meeting.id, item_number="2", title="Rezoning at 41st & Peoria"
+        )
+    )
+    db.commit()
+
+    match = service.match_meeting(db, meeting)[0]
+    message = service.render_message(match)
+
+    assert f"/meetings?meeting={meeting.id}" in message
+    assert "Rezoning" in message
+    assert "Unsubscribe:" in message
+    assert "token=" in message
+    # Deep link precedes the optional summary
+    assert message.index("/meetings?meeting=") < message.index("Council considered")
+
+
+def test_subscriber_without_channels_queues_nothing(db, service):
+    _subscription(
+        db,
+        1,
+        topics=["housing"],
+        sms_notifications=False,
+        email_notifications=False,
+    )
+    meeting = _meeting(db, topics=["housing"])
+    assert service.queue_matches(db, meeting) == 0


### PR DESCRIPTION
Implements Iteration 3 of the design sketch: subscriptions as a retrieval job on ingest, deep links first, hardened consent, and feedback as the product backlog.

## Changes

- **Ingest-time watch matching** (`watch_service.py`): the moment a scraper upserts a new meeting, active confirmed subscriptions are matched dual-track (Engagic-style) — item-level keyword hits outrank topic-label hits, which outrank bare meeting-type interest. Matches queue per channel with dedup; matching is portable Python (no jsonb operators) and can never break ingestion.
- **Deep link first**: every alert leads with `/meetings?meeting=<id>` (absolute via the new `FRONTEND_URL` setting), then matched item titles; the AI summary is optional trailing content, never the whole message.
- **One-click unsubscribe** (`core/tokens.py`): HMAC-SHA256 signed, 180-day expiring tokens in every message, honored by `GET /subscriptions/unsubscribe?token=…` — no login, no enumerable IDs. Quiet hours, digest mode, and per-day caps remain on the subscription and are honored at dispatch. Zero auto-sends.
- **Feedback review queue** (`chat_feedback`, migration 010): `POST /chatbot/feedback` records thumbs-up/down anonymously, tagged with the routed intent; the admin queue (`GET /chatbot/feedback?reviewed=false`) plus a review endpoint make every miss a tracked corpus/prompt/tool fix.

Also merges main's CI workflow fix so checks run against the repaired pipeline.

## Verification

62 backend tests pass, including watch-match specificity ranking, channel queueing/dedup, message content ordering (deep link before summary), token round-trip/tamper/expiry, and feedback defaults.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_