### PR TITLE
Iteration 4: matters graph

### DIFF
--- a/backend/alembic/versions/011_add_matters_graph.py
+++ b/backend/alembic/versions/011_add_matters_graph.py
@@ -1,0 +1,77 @@
+"""Add matters graph: matters + matter_appearances
+
+Track the same legislative matter (ordinance, resolution, zoning
+application) across meetings so its process timeline is answerable from
+the record.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "011"
+down_revision = "010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "matters",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("matter_key", sa.String(100), nullable=False, unique=True),
+        sa.Column("matter_type", sa.String(50), index=True),
+        sa.Column("title", sa.String(500)),
+        sa.Column("description", sa.Text()),
+        sa.Column("status", sa.String(50), server_default="active", index=True),
+        sa.Column("first_seen_date", sa.DateTime(timezone=True)),
+        sa.Column("last_seen_date", sa.DateTime(timezone=True)),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+    op.create_index("ix_matters_matter_key", "matters", ["matter_key"], unique=True)
+
+    op.create_table(
+        "matter_appearances",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "matter_id",
+            sa.Integer(),
+            sa.ForeignKey("matters.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "meeting_id",
+            sa.Integer(),
+            sa.ForeignKey("meetings.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "agenda_item_id", sa.Integer(), sa.ForeignKey("agenda_items.id")
+        ),
+        sa.Column("appeared_on", sa.DateTime(timezone=True)),
+        sa.Column("action", sa.String(50), server_default="discussed"),
+        sa.Column("vote_result", sa.String(50)),
+        sa.Column("evidence", sa.Text()),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.UniqueConstraint(
+            "matter_id", "meeting_id", "agenda_item_id", name="uq_matter_sighting"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("matter_appearances")
+    op.drop_index("ix_matters_matter_key", table_name="matters")
+    op.drop_table("matters")

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -6,6 +6,7 @@ from .endpoints import (
     campaigns,
     chatbot,
     documents,
+    matters,
     meeting_images,
     meetings,
     organizations,
@@ -36,6 +37,7 @@ api_router.include_router(
 api_router.include_router(campaigns.router, prefix="/campaigns", tags=["campaigns"])
 api_router.include_router(documents.router, prefix="/documents", tags=["documents"])
 api_router.include_router(budget.router, prefix="/budget", tags=["budget"])
+api_router.include_router(matters.router, prefix="/matters", tags=["matters"])
 
 # TODO: Add other routers as they are created
 # api_router.include_router(users.router, prefix="/users", tags=["users"])

--- a/backend/app/api/v1/endpoints/matters.py
+++ b/backend/app/api/v1/endpoints/matters.py
@@ -1,0 +1,115 @@
+"""Matters graph endpoints: legislative matters tracked across meetings.
+
+The exit criterion for this surface: "where is matter X in the process?"
+answered from the graph — with a timeline of sightings, each deep-linked
+to its meeting record — not from a similarity search.
+"""
+
+from typing import Optional
+
+from app.core.database import get_db
+from app.models.matter import Matter, MatterAppearance
+from app.models.meeting import Meeting
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session
+
+router = APIRouter()
+
+
+def _timeline(db: Session, matter: Matter) -> list:
+    rows = (
+        db.query(MatterAppearance, Meeting)
+        .join(Meeting, Meeting.id == MatterAppearance.meeting_id)
+        .filter(MatterAppearance.matter_id == matter.id)
+        .order_by(MatterAppearance.appeared_on)
+        .all()
+    )
+    return [
+        {
+            "meeting_id": meeting.id,
+            "meeting_title": meeting.title,
+            "date": appearance.appeared_on,
+            "action": appearance.action,
+            "vote_result": appearance.vote_result,
+            "agenda_item_id": appearance.agenda_item_id,
+            "evidence": (appearance.evidence or "")[:300],
+            "deep_link": f"/meetings?meeting={meeting.id}",
+        }
+        for appearance, meeting in rows
+    ]
+
+
+def _matter_payload(db: Session, matter: Matter, with_timeline: bool = True) -> dict:
+    payload = {
+        "id": matter.id,
+        "matter_key": matter.matter_key,
+        "matter_type": matter.matter_type,
+        "title": matter.title,
+        "status": matter.status,
+        "first_seen_date": matter.first_seen_date,
+        "last_seen_date": matter.last_seen_date,
+    }
+    if with_timeline:
+        payload["timeline"] = _timeline(db, matter)
+    return payload
+
+
+@router.get("/")
+async def list_matters(
+    status: Optional[str] = Query(None),
+    matter_type: Optional[str] = Query(None),
+    q: Optional[str] = Query(None, description="Search key and title"),
+    limit: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+):
+    """List tracked matters with appearance counts"""
+    query = db.query(
+        Matter, func.count(MatterAppearance.id).label("appearance_count")
+    ).outerjoin(MatterAppearance, MatterAppearance.matter_id == Matter.id)
+
+    if status:
+        query = query.filter(Matter.status == status)
+    if matter_type:
+        query = query.filter(Matter.matter_type == matter_type)
+    if q:
+        pattern = f"%{q}%"
+        query = query.filter(
+            or_(Matter.matter_key.ilike(pattern), Matter.title.ilike(pattern))
+        )
+
+    rows = (
+        query.group_by(Matter.id)
+        .order_by(Matter.last_seen_date.desc().nullslast())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "matters": [
+            {**_matter_payload(db, matter, with_timeline=False), "appearances": count}
+            for matter, count in rows
+        ],
+        "total": len(rows),
+    }
+
+
+@router.get("/by-key/{matter_key}")
+async def get_matter_by_key(matter_key: str, db: Session = Depends(get_db)):
+    """Canonical lookup: where is matter X in the process?"""
+    matter = (
+        db.query(Matter)
+        .filter(Matter.matter_key == matter_key.strip().lower())
+        .first()
+    )
+    if not matter:
+        raise HTTPException(status_code=404, detail="Matter not found")
+    return _matter_payload(db, matter)
+
+
+@router.get("/{matter_id}")
+async def get_matter(matter_id: int, db: Session = Depends(get_db)):
+    """One matter with its full meeting timeline"""
+    matter = db.query(Matter).filter(Matter.id == matter_id).first()
+    if not matter:
+        raise HTTPException(status_code=404, detail="Matter not found")
+    return _matter_payload(db, matter)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from .document import (
     DocumentCollectionMembership,
 )
 from .feedback import ChatFeedback
+from .matter import Matter, MatterAppearance
 from .meeting import AgendaItem, Meeting, MeetingCategory
 from .notification import Notification, NotificationPreference, NotificationTemplate
 from .notification_preferences import NotificationPreferences
@@ -27,6 +28,8 @@ __all__ = [
     "Meeting",
     "AgendaItem",
     "MeetingCategory",
+    "Matter",
+    "MatterAppearance",
     "Document",
     "DocumentChunk",
     "DocumentCollection",

--- a/backend/app/models/matter.py
+++ b/backend/app/models/matter.py
@@ -1,0 +1,97 @@
+from app.core.database import Base
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+
+class Matter(Base):
+    """A legislative matter tracked across meetings.
+
+    An ordinance, resolution, or zoning application is one thing that
+    appears at many meetings (introduced → discussed → amended → voted).
+    "Where is matter X in the process?" is answered from this graph, not
+    from a similarity search. Identity comes from the matter_key — the
+    normalized official identifier (e.g. "z-7642", "ordinance-12345")
+    extracted from agenda item text.
+    """
+
+    __tablename__ = "matters"
+
+    id = Column(Integer, primary_key=True, index=True)
+
+    matter_key = Column(String(100), unique=True, nullable=False, index=True)
+    matter_type = Column(
+        String(50), index=True
+    )  # ordinance, resolution, zoning_application, pud, board_appeal, other
+    title = Column(String(500))  # best title seen so far
+    description = Column(Text)
+
+    # Current disposition, derived from the latest appearance.
+    status = Column(
+        String(50), default="active", index=True
+    )  # active, passed, failed, postponed, withdrawn
+
+    first_seen_date = Column(DateTime(timezone=True))
+    last_seen_date = Column(DateTime(timezone=True))
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    appearances = relationship(
+        "MatterAppearance",
+        back_populates="matter",
+        cascade="all, delete-orphan",
+        order_by="MatterAppearance.appeared_on",
+    )
+
+    def __repr__(self):
+        return f"<Matter({self.matter_key}, status={self.status})>"
+
+
+class MatterAppearance(Base):
+    """One sighting of a matter at one meeting (optionally one item).
+
+    Each appearance records what happened (the action), the vote result
+    if any, and the evidence span it was extracted from — the graph
+    never asserts more than the record shows.
+    """
+
+    __tablename__ = "matter_appearances"
+    __table_args__ = (
+        UniqueConstraint(
+            "matter_id", "meeting_id", "agenda_item_id", name="uq_matter_sighting"
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    matter_id = Column(
+        Integer, ForeignKey("matters.id"), nullable=False, index=True
+    )
+    meeting_id = Column(
+        Integer, ForeignKey("meetings.id"), nullable=False, index=True
+    )
+    agenda_item_id = Column(Integer, ForeignKey("agenda_items.id"), nullable=True)
+
+    appeared_on = Column(DateTime(timezone=True))  # the meeting date
+    action = Column(
+        String(50), default="discussed"
+    )  # introduced, discussed, amended, vote_passed, vote_failed, postponed
+    vote_result = Column(String(50))  # as recorded on the agenda item, if any
+    evidence = Column(Text)  # the text span the match came from
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    matter = relationship("Matter", back_populates="appearances")
+    meeting = relationship("Meeting")
+    agenda_item = relationship("AgendaItem")
+
+    def __repr__(self):
+        return f"<MatterAppearance(matter={self.matter_id}, meeting={self.meeting_id})>"

--- a/backend/app/services/chatbot_service.py
+++ b/backend/app/services/chatbot_service.py
@@ -471,6 +471,29 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                 },
             },
             {
+                "name": "track_matter",
+                "description": (
+                    "Track a legislative matter (ordinance, resolution, "
+                    "zoning application like Z-7642, PUD, BOA case) across "
+                    "meetings: its status and full timeline of "
+                    "introductions, discussions, and votes. Use for "
+                    "'where is X in the process?' questions."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "matter_key": {
+                            "type": "string",
+                            "description": (
+                                "The matter identifier as written, e.g. "
+                                "'Z-7642', 'PUD-829', 'Ordinance 25384'"
+                            ),
+                        }
+                    },
+                    "required": ["matter_key"],
+                },
+            },
+            {
                 "name": "search_meetings",
                 "description": (
                     "Find city council meetings by topic keyword and date "
@@ -610,6 +633,9 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
                     arguments.get("meeting_id"), arguments.get("item_number")
                 )
 
+            elif function_name == "track_matter":
+                return self._track_matter(arguments.get("matter_key", ""))
+
             elif function_name == "search_meetings":
                 return self._search_meetings(
                     arguments.get("topic", ""),
@@ -665,6 +691,56 @@ Be natural, conversational, and as helpful as possible in encouraging civic part
         if item.summary:
             result += f"Summary: {item.summary[:400]}\n"
         result += f"Deep link: /meetings?meeting={meeting_id}\n"
+        return result
+
+    def _track_matter(self, matter_key: str) -> str:
+        """Answer 'where is matter X?' from the matters graph"""
+        from app.models.matter import Matter, MatterAppearance
+        from app.services.matter_service import extract_matter_keys
+
+        if not matter_key.strip():
+            return "matter_key is required."
+
+        # Normalize whatever form the user gave ("Ordinance No. 25384",
+        # "z 7642") through the same extractor used at ingest.
+        extracted = extract_matter_keys(matter_key)
+        normalized = extracted[0][0] if extracted else matter_key.strip().lower()
+
+        matter = (
+            self.db.query(Matter).filter(Matter.matter_key == normalized).first()
+        )
+        if matter is None:
+            return (
+                f"No matter matching '{matter_key}' in the tracked record. "
+                "Do not guess its status; suggest checking "
+                "tulsacouncil.org or the meeting explorer."
+            )
+
+        rows = (
+            self.db.query(MatterAppearance, Meeting)
+            .join(Meeting, Meeting.id == MatterAppearance.meeting_id)
+            .filter(MatterAppearance.matter_id == matter.id)
+            .order_by(MatterAppearance.appeared_on)
+            .all()
+        )
+
+        result = (
+            f"Matter {matter.matter_key.upper()}"
+            f"{f' — {matter.title}' if matter.title else ''}\n"
+            f"Current status: {matter.status}\n"
+            f"Timeline ({len(rows)} appearance(s)):\n"
+        )
+        for appearance, meeting in rows:
+            date_str = (
+                appearance.appeared_on.strftime("%B %d, %Y")
+                if appearance.appeared_on
+                else "unknown date"
+            )
+            result += (
+                f"- {date_str}: {appearance.action}"
+                f"{f' ({appearance.vote_result})' if appearance.vote_result else ''}"
+                f" at {meeting.title} (deep link: /meetings?meeting={meeting.id})\n"
+            )
         return result
 
     def _search_meetings(self, topic: str, date_from, date_to) -> str:

--- a/backend/app/services/matter_service.py
+++ b/backend/app/services/matter_service.py
@@ -1,0 +1,215 @@
+"""Matters graph: extract legislative identifiers and track them across
+meetings.
+
+Tulsa agenda items reference matters by official identifiers — zoning
+applications ("Z-7642", "Z-7642-A"), PUDs ("PUD-829"), Board of
+Adjustment cases ("BOA-23145"), ordinances ("Ordinance No. 25384"), and
+resolutions. The same identifier appearing at multiple meetings is the
+same matter; linking sightings at ingest builds the intro → amend → vote
+timeline that answers "where is matter X in the process?" from the
+record.
+"""
+
+import logging
+import re
+from typing import List, Optional, Tuple
+
+from app.models.matter import Matter, MatterAppearance
+from app.models.meeting import AgendaItem, Meeting
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# Identifier patterns → (matter_type, normalized key prefix).
+# Order matters: more specific patterns first.
+_MATTER_PATTERNS: List[Tuple[re.Pattern, str, str]] = [
+    (
+        re.compile(r"\bordinance\s+(?:no\.?\s*)?(\d{3,6})\b", re.IGNORECASE),
+        "ordinance",
+        "ordinance",
+    ),
+    (
+        re.compile(r"\bresolution\s+(?:no\.?\s*)?(\d{3,6})\b", re.IGNORECASE),
+        "resolution",
+        "resolution",
+    ),
+    (
+        re.compile(r"\b(PUD)[-\s]?(\d{2,5}(?:-[A-Z])?)\b", re.IGNORECASE),
+        "pud",
+        "pud",
+    ),
+    (
+        re.compile(r"\b(BOA)[-\s]?(\d{3,6})\b", re.IGNORECASE),
+        "board_appeal",
+        "boa",
+    ),
+    (
+        re.compile(r"\b(Z)[-\s]?(\d{3,5}(?:-[A-Z])?)\b"),
+        "zoning_application",
+        "z",
+    ),
+]
+
+# Action inference from item text / vote results.
+_ACTION_KEYWORDS = [
+    ("vote_passed", ["passed", "approved", "adopted"]),
+    ("vote_failed", ["failed", "denied", "rejected"]),
+    ("postponed", ["postponed", "continued", "tabled", "deferred"]),
+    ("amended", ["amend", "amendment", "substitute"]),
+    ("introduced", ["first reading", "introduce", "introduction"]),
+]
+
+# Matter statuses that a later sighting can no longer downgrade.
+_TERMINAL_ACTIONS = {"vote_passed": "passed", "vote_failed": "failed"}
+
+
+def extract_matter_keys(text: str) -> List[Tuple[str, str, str]]:
+    """Extract (matter_key, matter_type, evidence) triples from text.
+
+    Keys are normalized ("Z-7642" → "z-7642", "Ordinance No. 25384" →
+    "ordinance-25384") so the same matter matches across formats.
+    """
+    if not text:
+        return []
+
+    found = []
+    seen = set()
+    for pattern, matter_type, prefix in _MATTER_PATTERNS:
+        for match in pattern.finditer(text):
+            number = match.group(match.lastindex).upper()
+            key = f"{prefix}-{number.lower()}"
+            if key in seen:
+                continue
+            seen.add(key)
+            start = max(0, match.start() - 40)
+            evidence = text[start : match.end() + 60].strip()
+            found.append((key, matter_type, evidence))
+    return found
+
+
+def infer_action(item: Optional[AgendaItem], evidence: str) -> Tuple[str, Optional[str]]:
+    """Infer what happened to the matter at this sighting.
+
+    The structured vote_result on the agenda item wins; otherwise keyword
+    inference over the item text. Defaults to 'discussed'.
+    """
+    vote_result = item.vote_result if item is not None else None
+    haystack_parts = [evidence or ""]
+    if item is not None:
+        haystack_parts.extend([item.title or "", item.description or ""])
+    haystack = " ".join(haystack_parts).lower()
+
+    if vote_result:
+        lowered = vote_result.lower()
+        if lowered in ("passed", "approved", "adopted"):
+            return "vote_passed", vote_result
+        if lowered in ("failed", "denied", "rejected"):
+            return "vote_failed", vote_result
+
+    for action, keywords in _ACTION_KEYWORDS:
+        if any(keyword in haystack for keyword in keywords):
+            return action, vote_result
+
+    return "discussed", vote_result
+
+
+class MatterService:
+    """Link meetings into the matters graph at ingest time"""
+
+    def link_meeting_matters(self, db: Session, meeting: Meeting) -> int:
+        """Scan a meeting's agenda items for matter identifiers and record
+        appearances. Idempotent per (matter, meeting, item). Returns the
+        number of new appearances."""
+        agenda_items = (
+            db.query(AgendaItem).filter(AgendaItem.meeting_id == meeting.id).all()
+        )
+
+        # Scan items first (strong identity); fall back to the meeting
+        # summary for matters mentioned outside item structure.
+        sightings = []  # (key, type, evidence, item)
+        for item in agenda_items:
+            text = f"{item.title or ''}\n{item.description or ''}"
+            for key, matter_type, evidence in extract_matter_keys(text):
+                sightings.append((key, matter_type, evidence, item))
+        item_keys = {s[0] for s in sightings}
+        for key, matter_type, evidence in extract_matter_keys(meeting.summary or ""):
+            if key not in item_keys:
+                sightings.append((key, matter_type, evidence, None))
+
+        created = 0
+        for key, matter_type, evidence, item in sightings:
+            matter = db.query(Matter).filter(Matter.matter_key == key).first()
+            if matter is None:
+                matter = Matter(
+                    matter_key=key,
+                    matter_type=matter_type,
+                    title=(item.title[:500] if item and item.title else None),
+                )
+                db.add(matter)
+                db.flush()
+
+            existing = (
+                db.query(MatterAppearance)
+                .filter(
+                    MatterAppearance.matter_id == matter.id,
+                    MatterAppearance.meeting_id == meeting.id,
+                    MatterAppearance.agenda_item_id == (item.id if item else None),
+                )
+                .first()
+            )
+            if existing is not None:
+                continue
+
+            action, vote_result = infer_action(item, evidence)
+            db.add(
+                MatterAppearance(
+                    matter_id=matter.id,
+                    meeting_id=meeting.id,
+                    agenda_item_id=item.id if item else None,
+                    appeared_on=meeting.meeting_date,
+                    action=action,
+                    vote_result=vote_result,
+                    evidence=evidence[:1000],
+                )
+            )
+            created += 1
+
+            self._update_matter(matter, meeting, item, action)
+
+        if created:
+            db.flush()
+            logger.info(
+                f"Linked {created} matter appearances for meeting {meeting.id}"
+            )
+        return created
+
+    def _update_matter(
+        self,
+        matter: Matter,
+        meeting: Meeting,
+        item: Optional[AgendaItem],
+        action: str,
+    ) -> None:
+        """Roll the sighting into the matter's summary fields"""
+        if item is not None and item.title and not matter.title:
+            matter.title = item.title[:500]
+
+        when = meeting.meeting_date
+        if when is not None:
+            if matter.first_seen_date is None or when < matter.first_seen_date:
+                matter.first_seen_date = when
+            if matter.last_seen_date is None or when > matter.last_seen_date:
+                matter.last_seen_date = when
+
+        # Status: only the latest sighting may change it, and terminal
+        # outcomes stick unless a later meeting revisits the matter.
+        is_latest = matter.last_seen_date is None or (
+            when is not None and when >= matter.last_seen_date
+        )
+        if is_latest:
+            if action in _TERMINAL_ACTIONS:
+                matter.status = _TERMINAL_ACTIONS[action]
+            elif action == "postponed":
+                matter.status = "postponed"
+            elif matter.status not in _TERMINAL_ACTIONS.values():
+                matter.status = "active"

--- a/backend/app/services/meeting_upsert_service.py
+++ b/backend/app/services/meeting_upsert_service.py
@@ -89,6 +89,14 @@ class MeetingUpsertService:
                 if pdf_storage_path:
                     meeting.minutes_url = pdf_storage_path
 
+                # Clear matter appearances first (they reference agenda
+                # items and are re-derived when matters are re-linked below)
+                from app.models.matter import MatterAppearance
+
+                db.query(MatterAppearance).filter(
+                    MatterAppearance.meeting_id == meeting.id
+                ).delete()
+
                 # Clear existing agenda items (will be recreated)
                 db.query(AgendaItem).filter(
                     AgendaItem.meeting_id == meeting.id
@@ -112,6 +120,16 @@ class MeetingUpsertService:
                     WatchService(settings).queue_matches(db, meeting)
                 except Exception as e:
                     logger.warning(f"Watch matching failed for {external_id}: {e}")
+
+            # Matters graph: link this meeting's agenda items to their
+            # legislative matters (runs on updates too — agenda items are
+            # recreated above). Never allowed to break ingestion.
+            try:
+                from app.services.matter_service import MatterService
+
+                MatterService().link_meeting_matters(db, meeting)
+            except Exception as e:
+                logger.warning(f"Matter linking failed for {external_id}: {e}")
 
             return meeting, is_new
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -128,6 +128,27 @@ corpus (the pgvector column is sized from config on fresh databases).
   admin queue (`GET /chatbot/feedback?reviewed=false`) is the product
   backlog — each miss becomes a corpus, prompt, or tool fix.
 
+## Matters graph (Iteration 4)
+
+- **Longitudinal tracking** (`app/services/matter_service.py`): official
+  identifiers — zoning applications (Z-7642), PUDs, BOA cases, ordinance
+  and resolution numbers — are extracted from agenda items at ingest and
+  resolved to a persistent `Matter`. Each sighting becomes a
+  `MatterAppearance` with the inferred action (introduced / discussed /
+  amended / postponed / vote_passed / vote_failed), the recorded vote
+  result, and the evidence span it came from.
+- **Status from the record**: a matter's status derives from its latest
+  appearance; terminal outcomes (passed/failed) are never downgraded by
+  backfilling older meetings. The graph asserts only what the record shows.
+- **Surfaces**: `GET /api/v1/matters` (list/search), `/matters/{id}` and
+  `/matters/by-key/{key}` (timeline with per-meeting deep links), and the
+  chatbot's `track_matter` tool — "where is Z-7642 in the process?" is
+  answered from the graph, with a refusal when the matter isn't tracked.
+- **Deliberately out (for now)**: transcript/video sync (Tulsa publishes no
+  A/V feed we ingest) and councilor stance summaries — per the design
+  sketch those ship only with evidence spans and confidence labels, never
+  as unlabeled fact.
+
 ## Schema setup
 
 Fresh databases bootstrap via `create_tables()` (SQLAlchemy `create_all`) at
@@ -145,7 +166,7 @@ limitation inherited from the PoC.)
 | 1 — Evidence layer | provenance, hybrid index, item-level parsing, deep links | **shipped** on this branch (vendor-adapter hardening for TGOV/Granicus feeds remains ongoing) |
 | 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | **largely shipped**: intent router, budget tools, agent loop, claim verification, contested-issue policy, eval harness seed. Remaining: cross-encoder rerank, gold set expansion from research-day transcripts |
 | 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | **largely shipped**: dual-track matching at ingest, deep-link-first messages, signed one-click unsubscribe, feedback review queue. Remaining: digest dispatch loop, alert-retention metrics |
-| 4 — Matters graph | track legislative matters across meetings; optional media | not started |
+| 4 — Matters graph | track legislative matters across meetings; optional media | **core shipped**: identifier extraction, cross-meeting timelines, status inference, API + track_matter tool. Remaining: media/transcripts (needs a city A/V source), evidence-labeled stance summaries |
 
 The failure modes in the design sketch are the acceptance tests: if budget
 questions are still answered from chunk soup without citations, it isn't an

--- a/tests/backend/test_matter_service.py
+++ b/tests/backend/test_matter_service.py
@@ -1,0 +1,177 @@
+"""Tests for the matters graph: extraction, cross-meeting tracking,
+status inference, and the track_matter chatbot tool."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings  # noqa: E402
+from app.core.database import Base  # noqa: E402
+from app.models.matter import Matter, MatterAppearance  # noqa: E402
+from app.models.meeting import AgendaItem, Meeting  # noqa: E402
+from app.services.chatbot_service import ChatbotService  # noqa: E402
+from app.services.matter_service import (  # noqa: E402
+    MatterService,
+    extract_matter_keys,
+)
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+
+@pytest.fixture
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    session = sessionmaker(bind=engine)()
+    yield session
+    session.close()
+
+
+def _meeting(db, meeting_id, date, title="Regular Council Meeting"):
+    meeting = Meeting(
+        id=meeting_id,
+        title=title,
+        meeting_type="city_council",
+        meeting_date=date,
+        source="test",
+    )
+    db.add(meeting)
+    db.commit()
+    return meeting
+
+
+def _item(db, meeting_id, item_id, title, vote_result=None, description=""):
+    item = AgendaItem(
+        id=item_id,
+        meeting_id=meeting_id,
+        item_number=str(item_id),
+        title=title,
+        description=description,
+        vote_result=vote_result,
+    )
+    db.add(item)
+    db.commit()
+    return item
+
+
+class TestExtraction:
+    def test_zoning_application(self):
+        keys = extract_matter_keys("Rezoning application Z-7642 at 41st and Peoria")
+        assert ("z-7642", "zoning_application") == keys[0][:2]
+
+    def test_zoning_amendment_suffix(self):
+        keys = extract_matter_keys("Application Z-7642-A (amended)")
+        assert keys[0][0] == "z-7642-a"
+
+    def test_ordinance_number_forms(self):
+        assert extract_matter_keys("Ordinance No. 25384 adopting...")[0][0] == (
+            "ordinance-25384"
+        )
+        assert extract_matter_keys("ordinance 25384")[0][0] == "ordinance-25384"
+
+    def test_pud_and_boa(self):
+        text = "PUD-829 and BOA-23145 are both scheduled"
+        keys = {k for k, _, _ in extract_matter_keys(text)}
+        assert keys == {"pud-829", "boa-23145"}
+
+    def test_no_false_positives_on_prose(self):
+        assert extract_matter_keys("The council discussed parks funding.") == []
+
+    def test_dedupes_repeated_keys(self):
+        keys = extract_matter_keys("Z-7642 ... later Z-7642 again")
+        assert len(keys) == 1
+
+
+class TestGraph:
+    def test_same_matter_across_meetings(self, db):
+        service = MatterService()
+
+        first = _meeting(db, 1, datetime(2025, 5, 7, 17, 0))
+        _item(db, 1, 10, "Rezoning application Z-7642 — first reading")
+        service.link_meeting_matters(db, first)
+
+        second = _meeting(db, 2, datetime(2025, 6, 4, 17, 0))
+        _item(db, 2, 20, "Rezoning application Z-7642", vote_result="passed")
+        service.link_meeting_matters(db, second)
+
+        matters = db.query(Matter).all()
+        assert len(matters) == 1
+        matter = matters[0]
+        assert matter.matter_key == "z-7642"
+        assert matter.status == "passed"
+        assert matter.first_seen_date == first.meeting_date
+        assert matter.last_seen_date == second.meeting_date
+
+        actions = [
+            a.action
+            for a in db.query(MatterAppearance)
+            .order_by(MatterAppearance.appeared_on)
+            .all()
+        ]
+        assert actions == ["introduced", "vote_passed"]
+
+    def test_relinking_is_idempotent(self, db):
+        service = MatterService()
+        meeting = _meeting(db, 1, datetime(2025, 5, 7))
+        _item(db, 1, 10, "Ordinance No. 25384 — adoption", vote_result="passed")
+
+        assert service.link_meeting_matters(db, meeting) == 1
+        assert service.link_meeting_matters(db, meeting) == 0
+        assert db.query(MatterAppearance).count() == 1
+
+    def test_postponed_status(self, db):
+        service = MatterService()
+        meeting = _meeting(db, 1, datetime(2025, 5, 7))
+        _item(db, 1, 10, "PUD-829 major amendment — continued to June 4")
+        service.link_meeting_matters(db, meeting)
+
+        matter = db.query(Matter).one()
+        assert matter.status == "postponed"
+
+    def test_terminal_status_not_downgraded_by_older_meeting(self, db):
+        """Backfilling an older meeting must not overwrite a final vote"""
+        service = MatterService()
+
+        newer = _meeting(db, 1, datetime(2025, 6, 4))
+        _item(db, 1, 10, "Z-7642 rezoning", vote_result="passed")
+        service.link_meeting_matters(db, newer)
+
+        older = _meeting(db, 2, datetime(2025, 4, 2))
+        _item(db, 2, 20, "Z-7642 rezoning — first reading")
+        service.link_meeting_matters(db, older)
+
+        matter = db.query(Matter).one()
+        assert matter.status == "passed"
+        assert matter.first_seen_date == older.meeting_date
+
+
+class TestTrackMatterTool:
+    @pytest.fixture
+    def chatbot(self, db):
+        return ChatbotService(db, Settings())
+
+    @pytest.mark.asyncio
+    async def test_timeline_answer_with_deep_links(self, db, chatbot):
+        service = MatterService()
+        meeting = _meeting(db, 1, datetime(2025, 6, 4))
+        _item(db, 1, 10, "Rezoning application Z-7642", vote_result="passed")
+        service.link_meeting_matters(db, meeting)
+
+        result = await chatbot.process_function_call(
+            "track_matter", {"matter_key": "Z-7642"}
+        )
+        assert "Z-7642" in result.upper()
+        assert "passed" in result
+        assert "/meetings?meeting=1" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_matter_refuses(self, db, chatbot):
+        result = await chatbot.process_function_call(
+            "track_matter", {"matter_key": "Z-9999"}
+        )
+        assert "Do not guess" in result


### PR DESCRIPTION
Implements the core of Iteration 4: track the same legislative matter across meetings so "where is matter X in the process?" is answered from the graph, not a vibe.

## Changes

- **Matter + MatterAppearance models** (migration 011): a matter is one ordinance/resolution/zoning application/PUD/BOA case identified by its normalized official key (`z-7642`, `ordinance-25384`); each sighting records the meeting, agenda item, inferred action (introduced → discussed → amended → postponed → vote_passed/failed), vote result, and the evidence span it was extracted from
- **Ingest-time linking**: matters are (re)linked whenever a meeting is upserted, next to watch matching; idempotent per sighting; status follows the latest appearance and terminal outcomes are never downgraded by backfilling older meetings; linking can never break ingestion
- **API**: `GET /matters` (search + appearance counts), `/matters/{id}` and `/matters/by-key/{key}` — full intro→amend→vote timeline, each step deep-linked to its meeting record
- **Chatbot `track_matter` tool**: normalizes whatever form a resident types through the ingest extractor, answers from the graph, refuses with official-source pointers when a matter isn't tracked

Deliberately deferred per the design sketch: transcript/video sync (needs a city A/V source) and councilor stance summaries (only shippable with evidence spans + confidence labels).

## Verification

74 backend tests pass (12 new): extraction formats, cross-meeting identity, idempotent relinking, status inference including backfill safety, and tool output with deep links and refusals.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_