### PR TITLE
Transcript/video sync with free GitHub Actions transcription

### DIFF
--- a/.github/workflows/transcribe.yml
+++ b/.github/workflows/transcribe.yml
@@ -1,0 +1,79 @@
+name: Transcribe Meeting Video
+
+# Free transcript/video sync: runs Whisper on a standard GitHub-hosted
+# runner (no GPU, no paid API). A ~3h council meeting transcribes in
+# roughly 60-90 minutes with the base.en model — well inside the 6h job
+# limit, at zero cost on a public repository.
+#
+# Trigger manually from the Actions tab with the meeting's video URL and
+# its CivicSpark meeting ID. The transcript JSON is always saved as a
+# run artifact; it is also POSTed to the API when the two repository
+# secrets are configured:
+#   CIVICSPARK_API_URL          e.g. https://civicspark-api.onrender.com
+#   TRANSCRIPT_INGEST_TOKEN     must match the API's TRANSCRIPT_INGEST_TOKEN
+
+on:
+  workflow_dispatch:
+    inputs:
+      video_url:
+        description: "Meeting video URL (direct mp4 or stream ffmpeg can read)"
+        required: true
+        type: string
+      meeting_id:
+        description: "CivicSpark meeting ID to attach the transcript to"
+        required: true
+        type: string
+      model:
+        description: "Whisper model"
+        required: false
+        default: "base.en"
+        type: choice
+        options: ["tiny.en", "base.en", "small.en"]
+
+jobs:
+  transcribe:
+    name: Transcribe (${{ inputs.model }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 320
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q ffmpeg
+
+      - name: Install transcription dependencies
+        run: pip install --quiet faster-whisper requests
+
+      - name: Transcribe
+        env:
+          CIVICSPARK_API_URL: ${{ secrets.CIVICSPARK_API_URL }}
+          TRANSCRIPT_INGEST_TOKEN: ${{ secrets.TRANSCRIPT_INGEST_TOKEN }}
+        run: |
+          EXTRA_ARGS=""
+          if [ -n "$CIVICSPARK_API_URL" ] && [ -n "$TRANSCRIPT_INGEST_TOKEN" ]; then
+            EXTRA_ARGS="--api-url $CIVICSPARK_API_URL --api-token $TRANSCRIPT_INGEST_TOKEN"
+          else
+            echo "::notice::API secrets not configured - transcript saved as artifact only"
+          fi
+          python scripts/transcribe_meeting.py \
+            --video-url "${{ inputs.video_url }}" \
+            --meeting-id "${{ inputs.meeting_id }}" \
+            --model "${{ inputs.model }}" \
+            --output "transcript-meeting-${{ inputs.meeting_id }}.json" \
+            $EXTRA_ARGS
+
+      - name: Upload transcript artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: transcript-meeting-${{ inputs.meeting_id }}
+          path: transcript-meeting-${{ inputs.meeting_id }}.json
+          retention-days: 90

--- a/backend/alembic/versions/012_add_transcript_segments.py
+++ b/backend/alembic/versions/012_add_transcript_segments.py
@@ -1,0 +1,62 @@
+"""Add transcript segments and meeting video URL
+
+Timestamped transcript spans sync quotes to the meeting video. The
+video_url column on meetings records the source recording.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        conn.execute(
+            text("ALTER TABLE meetings ADD COLUMN IF NOT EXISTS video_url VARCHAR")
+        )
+    else:
+        op.add_column("meetings", sa.Column("video_url", sa.String(), nullable=True))
+
+    op.create_table(
+        "transcript_segments",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "meeting_id",
+            sa.Integer(),
+            sa.ForeignKey("meetings.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("segment_index", sa.Integer(), nullable=False),
+        sa.Column("start_seconds", sa.Float(), nullable=False),
+        sa.Column("end_seconds", sa.Float(), nullable=False),
+        sa.Column("text", sa.Text(), nullable=False),
+        sa.Column(
+            "agenda_item_id", sa.Integer(), sa.ForeignKey("agenda_items.id")
+        ),
+        sa.Column("source_model", sa.String(100)),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("transcript_segments")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        conn.execute(text("ALTER TABLE meetings DROP COLUMN IF EXISTS video_url"))
+    else:
+        op.drop_column("meetings", "video_url")

--- a/backend/app/api/v1/endpoints/meetings.py
+++ b/backend/app/api/v1/endpoints/meetings.py
@@ -5,10 +5,14 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional
 
+import hmac
+
 import httpx
+from app.core.config import Settings, get_settings
 from app.core.database import get_db
 from app.models.document import DocumentChunk
 from app.models.meeting import AgendaItem, Meeting, MeetingCategory
+from app.models.transcript import TranscriptSegment
 from app.schemas.base import PaginationParams, StandardListResponse
 from app.schemas.meeting import (
     AgendaItemResponse,
@@ -19,7 +23,7 @@ from app.schemas.meeting import (
     MeetingResponse,
 )
 from app.services.ai_categorization_service import AICategorization
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from pydantic import BaseModel
@@ -311,6 +315,126 @@ async def get_agenda_item(
             for chunk in chunks
         ],
         "deep_link": f"/meetings?meeting={meeting_id}",
+    }
+
+
+class TranscriptSegmentIn(BaseModel):
+    start: float
+    end: float
+    text: str
+
+
+class TranscriptUpload(BaseModel):
+    video_url: Optional[str] = None
+    source_model: Optional[str] = None
+    segments: List[TranscriptSegmentIn]
+
+
+def _require_ingest_token(
+    settings: Settings, x_ingest_token: Optional[str]
+) -> None:
+    """Shared-secret auth for machine ingest (the transcription workflow)"""
+    expected = settings.transcript_ingest_token
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Transcript ingest is not configured on this deployment",
+        )
+    if not x_ingest_token or not hmac.compare_digest(x_ingest_token, expected):
+        raise HTTPException(status_code=403, detail="Invalid ingest token")
+
+
+@router.post("/{meeting_id}/transcript")
+async def upload_transcript(
+    meeting_id: int,
+    payload: TranscriptUpload,
+    x_ingest_token: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    """Replace a meeting's transcript (machine ingest).
+
+    Called by the free GitHub Actions transcription workflow with the
+    TRANSCRIPT_INGEST_TOKEN shared secret. Segments are replaced
+    atomically so re-transcribing with a better model is idempotent.
+    """
+    _require_ingest_token(settings, x_ingest_token)
+
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+    if not meeting:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+    if not payload.segments:
+        raise HTTPException(status_code=400, detail="No segments provided")
+
+    db.query(TranscriptSegment).filter(
+        TranscriptSegment.meeting_id == meeting_id
+    ).delete()
+
+    for index, segment in enumerate(payload.segments):
+        db.add(
+            TranscriptSegment(
+                meeting_id=meeting_id,
+                segment_index=index,
+                start_seconds=segment.start,
+                end_seconds=segment.end,
+                text=segment.text.strip(),
+                source_model=payload.source_model,
+            )
+        )
+
+    if payload.video_url:
+        meeting.video_url = payload.video_url
+
+    db.commit()
+    return {
+        "message": "Transcript stored",
+        "meeting_id": meeting_id,
+        "segments": len(payload.segments),
+    }
+
+
+@router.get("/{meeting_id}/transcript")
+async def get_transcript(
+    meeting_id: int,
+    q: Optional[str] = Query(None, description="Filter segments by text"),
+    limit: int = Query(500, ge=1, le=2000),
+    db: Session = Depends(get_db),
+):
+    """A meeting's transcript, each segment linked to its video moment"""
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+    if not meeting:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    query = db.query(TranscriptSegment).filter(
+        TranscriptSegment.meeting_id == meeting_id
+    )
+    if q:
+        query = query.filter(TranscriptSegment.text.ilike(f"%{q}%"))
+
+    segments = query.order_by(TranscriptSegment.segment_index).limit(limit).all()
+
+    def video_link(start: float) -> Optional[str]:
+        if not meeting.video_url:
+            return None
+        # Media-fragment offset works for direct files; Granicus players
+        # also accept an explicit start position.
+        return f"{meeting.video_url}#t={int(start)}"
+
+    return {
+        "meeting_id": meeting_id,
+        "video_url": meeting.video_url,
+        "segment_count": len(segments),
+        "source_model": segments[0].source_model if segments else None,
+        "segments": [
+            {
+                "index": segment.segment_index,
+                "start": segment.start_seconds,
+                "end": segment.end_seconds,
+                "text": segment.text,
+                "video_link": video_link(segment.start_seconds),
+            }
+            for segment in segments
+        ],
     }
 
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -94,6 +94,11 @@ class Settings(BaseSettings):
     # notifications (e.g. https://civicspark.vercel.app). Empty = relative.
     frontend_url: str = ""
 
+    # Machine-ingest shared secret for the transcription workflow
+    # (GitHub Actions posts transcripts with this token). Feature is
+    # disabled when unset.
+    transcript_ingest_token: Optional[str] = None
+
     # RAG Configuration
     enable_rag: bool = True
     # Second-pass claim verification on tool-grounded answers (refuse > invent)

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -93,7 +93,7 @@ async def citycamp_exception_handler(
         error=exc.message, error_code=exc.error_code, details=exc.details
     )
 
-    return JSONResponse(status_code=exc.status_code, content=error_response.dict())
+    return JSONResponse(status_code=exc.status_code, content=error_response.model_dump(mode="json"))
 
 
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
@@ -102,7 +102,7 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 
     error_response = ErrorResponse(error=exc.detail, error_code="HTTP_ERROR")
 
-    return JSONResponse(status_code=exc.status_code, content=error_response.dict())
+    return JSONResponse(status_code=exc.status_code, content=error_response.model_dump(mode="json"))
 
 
 async def validation_exception_handler(
@@ -118,7 +118,7 @@ async def validation_exception_handler(
     )
 
     return JSONResponse(
-        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=error_response.dict()
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, content=error_response.model_dump(mode="json")
     )
 
 
@@ -131,5 +131,5 @@ async def general_exception_handler(request: Request, exc: Exception) -> JSONRes
     )
 
     return JSONResponse(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=error_response.dict()
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, content=error_response.model_dump(mode="json")
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -18,6 +18,7 @@ from .meeting import AgendaItem, Meeting, MeetingCategory
 from .notification import Notification, NotificationPreference, NotificationTemplate
 from .notification_preferences import NotificationPreferences
 from .subscription import MeetingTopic, NotificationLog, TopicSubscription
+from .transcript import TranscriptSegment
 from .user import User, UserInterests
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "MeetingCategory",
     "Matter",
     "MatterAppearance",
+    "TranscriptSegment",
     "Document",
     "DocumentChunk",
     "DocumentCollection",

--- a/backend/app/models/meeting.py
+++ b/backend/app/models/meeting.py
@@ -27,6 +27,7 @@ class Meeting(Base):
     meeting_url = Column(String, nullable=True)  # Link to meeting details
     agenda_url = Column(String, nullable=True)  # Link to agenda PDF
     minutes_url = Column(String, nullable=True)  # Link to meeting minutes
+    video_url = Column(String, nullable=True)  # Meeting video recording
     status = Column(
         String, default="scheduled"
     )  # scheduled, in_progress, completed, cancelled

--- a/backend/app/models/transcript.py
+++ b/backend/app/models/transcript.py
@@ -1,0 +1,52 @@
+from app.core.database import Base
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+
+class TranscriptSegment(Base):
+    """One timestamped span of a meeting's video/audio transcript.
+
+    Segments carry start/end offsets into the meeting video, so every
+    quote links back to the moment it was said (the OpenCouncil.gr /
+    View Royal pattern). Produced by the free GitHub Actions
+    transcription workflow (`.github/workflows/transcribe.yml`), which
+    runs Whisper on CPU and posts results to the ingest endpoint.
+    """
+
+    __tablename__ = "transcript_segments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    meeting_id = Column(
+        Integer, ForeignKey("meetings.id"), nullable=False, index=True
+    )
+
+    segment_index = Column(Integer, nullable=False)  # order within meeting
+    start_seconds = Column(Float, nullable=False)
+    end_seconds = Column(Float, nullable=False)
+    text = Column(Text, nullable=False)
+
+    # Optional link to the agenda item under discussion (future: aligned
+    # via item timestamps when the source publishes them).
+    agenda_item_id = Column(Integer, ForeignKey("agenda_items.id"), nullable=True)
+
+    # Provenance: which model produced this segment.
+    source_model = Column(String(100))  # e.g. "faster-whisper/base.en"
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    meeting = relationship("Meeting")
+
+    def __repr__(self):
+        return (
+            f"<TranscriptSegment(meeting={self.meeting_id}, "
+            f"{self.start_seconds:.0f}s)>"
+        )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,10 +144,16 @@ corpus (the pgvector column is sized from config on fresh databases).
   `/matters/by-key/{key}` (timeline with per-meeting deep links), and the
   chatbot's `track_matter` tool — "where is Z-7642 in the process?" is
   answered from the graph, with a refusal when the matter isn't tracked.
-- **Deliberately out (for now)**: transcript/video sync (Tulsa publishes no
-  A/V feed we ingest) and councilor stance summaries — per the design
-  sketch those ship only with evidence spans and confidence labels, never
-  as unlabeled fact.
+- **Transcript/video sync**: meeting videos are transcribed for free on
+  GitHub Actions (`.github/workflows/transcribe.yml` → faster-whisper on
+  CPU; a ~3h meeting fits well inside the 6h job limit at $0). Timestamped
+  segments land in `transcript_segments` via a shared-secret machine-ingest
+  endpoint (`POST /meetings/{id}/transcript`, `TRANSCRIPT_INGEST_TOKEN`),
+  and `GET /meetings/{id}/transcript?q=` returns every quote with a
+  `video_link` pointing at its exact moment in the recording.
+- **Deliberately out (for now)**: councilor stance summaries — per the
+  design sketch those ship only with evidence spans and confidence labels,
+  never as unlabeled fact.
 
 ## Schema setup
 
@@ -166,7 +172,7 @@ limitation inherited from the PoC.)
 | 1 — Evidence layer | provenance, hybrid index, item-level parsing, deep links | **shipped** on this branch (vendor-adapter hardening for TGOV/Granicus feeds remains ongoing) |
 | 2 — Grounded Q&A | intent routing, rerank, claim verification, budget tools, gold eval set | **largely shipped**: intent router, budget tools, agent loop, claim verification, contested-issue policy, eval harness seed. Remaining: cross-encoder rerank, gold set expansion from research-day transcripts |
 | 3 — Watches & outreach | ingest-time watch matching, deep-link-first alerts, consent hardening | **largely shipped**: dual-track matching at ingest, deep-link-first messages, signed one-click unsubscribe, feedback review queue. Remaining: digest dispatch loop, alert-retention metrics |
-| 4 — Matters graph | track legislative matters across meetings; optional media | **core shipped**: identifier extraction, cross-meeting timelines, status inference, API + track_matter tool. Remaining: media/transcripts (needs a city A/V source), evidence-labeled stance summaries |
+| 4 — Matters graph | track legislative matters across meetings; optional media | **shipped**: identifier extraction, cross-meeting timelines, status inference, API + track_matter tool, free Actions-based transcript/video sync. Remaining: evidence-labeled stance summaries, transcript↔agenda-item alignment |
 
 The failure modes in the design sketch are the acceptance tests: if budget
 questions are still answered from chunk soup without citations, it isn't an

--- a/scripts/transcribe_meeting.py
+++ b/scripts/transcribe_meeting.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Transcribe a council meeting video with Whisper on CPU — for free.
+
+Designed to run inside the GitHub Actions workflow
+(.github/workflows/transcribe.yml) on a standard free runner:
+ffmpeg extracts a 16kHz mono audio track, faster-whisper (CTranslate2,
+int8) transcribes it, and the timestamped segments are written to JSON
+and optionally POSTed to the CivicSpark API.
+
+Usage:
+  python scripts/transcribe_meeting.py \
+      --video-url https://.../meeting.mp4 \
+      --meeting-id 42 \
+      --model base.en \
+      --output transcript.json \
+      [--api-url https://civicspark-api.onrender.com \
+       --api-token $TRANSCRIPT_INGEST_TOKEN]
+
+Dependencies (workflow-only, not part of backend requirements):
+  apt: ffmpeg
+  pip: faster-whisper requests
+"""
+
+import argparse
+import json
+import subprocess  # nosec B404 - ffmpeg invocation with fixed args
+import sys
+import tempfile
+from pathlib import Path
+
+
+def extract_audio(video_url: str, output_path: str) -> None:
+    """Download/extract a 16kHz mono wav from the video URL via ffmpeg"""
+    command = [
+        "ffmpeg",
+        "-y",
+        "-loglevel",
+        "error",
+        "-i",
+        video_url,
+        "-vn",
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        output_path,
+    ]
+    subprocess.run(command, check=True)  # nosec B603
+
+
+def transcribe(audio_path: str, model_name: str) -> list:
+    """Run faster-whisper over the audio; returns [{start, end, text}]"""
+    from faster_whisper import WhisperModel
+
+    model = WhisperModel(model_name, device="cpu", compute_type="int8")
+    segments_iter, info = model.transcribe(
+        audio_path,
+        vad_filter=True,
+        beam_size=5,
+    )
+    print(
+        f"Detected language {info.language} "
+        f"(p={info.language_probability:.2f}), duration {info.duration:.0f}s",
+        file=sys.stderr,
+    )
+
+    segments = []
+    for segment in segments_iter:
+        text = segment.text.strip()
+        if not text:
+            continue
+        segments.append(
+            {
+                "start": round(segment.start, 2),
+                "end": round(segment.end, 2),
+                "text": text,
+            }
+        )
+        # Progress heartbeat for long meetings in the Actions log.
+        if len(segments) % 100 == 0:
+            print(
+                f"... {len(segments)} segments ({segment.end / 60:.0f} min)",
+                file=sys.stderr,
+            )
+    return segments
+
+
+def upload(api_url: str, api_token: str, meeting_id: int, payload: dict) -> None:
+    import requests
+
+    response = requests.post(
+        f"{api_url.rstrip('/')}/api/v1/meetings/{meeting_id}/transcript",
+        json=payload,
+        headers={"X-Ingest-Token": api_token},
+        timeout=120,
+    )
+    response.raise_for_status()
+    print(f"Uploaded: {response.json()}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--video-url", required=True)
+    parser.add_argument("--meeting-id", required=True, type=int)
+    parser.add_argument("--model", default="base.en")
+    parser.add_argument("--output", default="transcript.json")
+    parser.add_argument("--api-url", default=None)
+    parser.add_argument("--api-token", default=None)
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        audio_path = str(Path(tmp) / "audio.wav")
+        print(f"Extracting audio from {args.video_url} ...", file=sys.stderr)
+        extract_audio(args.video_url, audio_path)
+
+        print(f"Transcribing with faster-whisper/{args.model} ...", file=sys.stderr)
+        segments = transcribe(audio_path, args.model)
+
+    if not segments:
+        print("No speech found; nothing to store.", file=sys.stderr)
+        return 1
+
+    payload = {
+        "video_url": args.video_url,
+        "source_model": f"faster-whisper/{args.model}",
+        "segments": segments,
+    }
+    Path(args.output).write_text(json.dumps(payload, indent=2))
+    print(f"Wrote {len(segments)} segments to {args.output}", file=sys.stderr)
+
+    if args.api_url and args.api_token:
+        upload(args.api_url, args.api_token, args.meeting_id, payload)
+    else:
+        print(
+            "API upload skipped (set --api-url/--api-token to ingest).",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/backend/test_transcripts.py
+++ b/tests/backend/test_transcripts.py
@@ -1,0 +1,133 @@
+"""Tests for transcript ingest and video-synced retrieval."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings, get_settings  # noqa: E402
+from app.core.database import Base, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models.meeting import Meeting  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+INGEST_TOKEN = "test-ingest-token-not-secret"  # nosec B105
+
+SEGMENTS = [
+    {"start": 0.0, "end": 4.5, "text": "This meeting will come to order."},
+    {"start": 4.5, "end": 12.0, "text": "First item, rezoning application Z-7642."},
+    {"start": 12.0, "end": 20.0, "text": "The motion passes unanimously."},
+]
+
+
+@pytest.fixture
+def client():
+    # StaticPool: every connection shares the single in-memory database
+    # (TestClient handlers run on another thread with their own checkout).
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestingSession = sessionmaker(bind=engine)
+    session = TestingSession()
+
+    session.add(
+        Meeting(
+            id=1,
+            title="Regular Council Meeting",
+            meeting_type="city_council",
+            meeting_date=datetime(2026, 6, 3, 17, 0),
+            source="test",
+        )
+    )
+    session.commit()
+
+    def override_db():
+        yield session
+
+    def override_settings():
+        return Settings(transcript_ingest_token=INGEST_TOKEN)
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_settings] = override_settings
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+    session.close()
+
+
+def _upload(client, token=INGEST_TOKEN, meeting_id=1, **overrides):
+    payload = {
+        "video_url": "https://tulsa-tgov.example/video/123.mp4",
+        "source_model": "faster-whisper/base.en",
+        "segments": SEGMENTS,
+        **overrides,
+    }
+    headers = {"X-Ingest-Token": token} if token else {}
+    return client.post(
+        f"/api/v1/meetings/{meeting_id}/transcript", json=payload, headers=headers
+    )
+
+
+def test_upload_requires_token(client):
+    assert _upload(client, token=None).status_code == 403
+    assert _upload(client, token="wrong-token").status_code == 403
+
+
+def test_upload_rejected_when_feature_unconfigured(client):
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        transcript_ingest_token=None
+    )
+    assert _upload(client).status_code == 503
+
+
+def test_upload_and_video_synced_retrieval(client):
+    response = _upload(client)
+    assert response.status_code == 200
+    assert response.json()["segments"] == 3
+
+    got = client.get("/api/v1/meetings/1/transcript")
+    assert got.status_code == 200
+    data = got.json()
+    assert data["segment_count"] == 3
+    assert data["source_model"] == "faster-whisper/base.en"
+    # Every segment links to its moment in the video
+    assert data["segments"][1]["video_link"].endswith("123.mp4#t=4")
+    assert data["segments"][2]["text"] == "The motion passes unanimously."
+
+
+def test_reupload_replaces_segments(client):
+    _upload(client)
+    _upload(
+        client,
+        segments=[{"start": 0.0, "end": 3.0, "text": "Better transcription."}],
+        source_model="faster-whisper/small.en",
+    )
+
+    data = client.get("/api/v1/meetings/1/transcript").json()
+    assert data["segment_count"] == 1
+    assert data["source_model"] == "faster-whisper/small.en"
+
+
+def test_transcript_search_filters_segments(client):
+    _upload(client)
+    data = client.get("/api/v1/meetings/1/transcript?q=Z-7642").json()
+    assert data["segment_count"] == 1
+    assert "Z-7642" in data["segments"][0]["text"]
+
+
+def test_unknown_meeting_404s(client):
+    assert _upload(client, meeting_id=99).status_code == 404
+    assert client.get("/api/v1/meetings/99/transcript").status_code == 404
+
+
+def test_empty_segments_rejected(client):
+    assert _upload(client, segments=[]).status_code == 400


### PR DESCRIPTION
Completes Iteration 4's optional media track: meeting videos become searchable, timestamped transcripts where every quote links to its moment in the recording — at zero infrastructure cost.

## Changes

- **TranscriptSegment model + `meetings.video_url`** (migration 012): timestamped spans with source-model provenance
- **Machine ingest**: `POST /meetings/{id}/transcript` guarded by the `TRANSCRIPT_INGEST_TOKEN` shared secret (constant-time compare; 503 until configured). Segments replace atomically, so re-transcribing with a better model is idempotent
- **Video-synced retrieval**: `GET /meetings/{id}/transcript?q=` — searchable segments, each with a `video_link` (`…#t=1284`) into the recording
- **Free transcription pipeline**: `.github/workflows/transcribe.yml` runs faster-whisper (CPU/int8) on a standard free runner via `scripts/transcribe_meeting.py`; a ~3h meeting fits well inside the 6h job limit. Transcript JSON is always kept as a run artifact and POSTed to the API when the `CIVICSPARK_API_URL` / `TRANSCRIPT_INGEST_TOKEN` secrets are set
- **Bug fix**: all four error handlers crashed serializing `ErrorResponse.timestamp`, turning every 403/404 into a 500 — fixed with `model_dump(mode="json")`

## Verification

81 backend tests pass (7 new: ingest auth, replace semantics, transcript search, timestamped links, plus the error-handler regression is now exercised by the 403/404 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_