### PR TITLE
Media platform: daily Granicus sync, translations, analysis, and meeting media UI

### DIFF
--- a/.github/workflows/daily-media-sync.yml
+++ b/.github/workflows/daily-media-sync.yml
@@ -1,0 +1,117 @@
+name: Daily Media Sync
+
+# Pulls new meeting videos from Granicus (TGOV) every day, transcribes
+# them with Whisper on free runners, translates the transcript to
+# Spanish, and stores an LLM analysis into the platform's topic
+# categories. Everything runs on GitHub's free compute; the only paid
+# dependency is nothing.
+#
+# Required repository secrets:
+#   CIVICSPARK_API_URL       e.g. https://civicspark-api.onrender.com
+#   TRANSCRIPT_INGEST_TOKEN  must match the API deployment's setting
+# Optional (enables translation + analysis):
+#   LLM_API_KEY              Groq (or any OpenAI-compatible provider)
+# Optional overrides:
+#   GRANICUS_VIEW_IDS        comma-separated view ids (default "4")
+
+on:
+  schedule:
+    - cron: '0 11 * * *'   # daily, ~6am Central
+  workflow_dispatch:
+
+jobs:
+  discover:
+    name: Discover new videos
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.match.outputs.matrix }}
+      has_jobs: ${{ steps.match.outputs.has_jobs }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install --quiet requests
+
+      - name: Match Granicus feed to pending meetings
+        id: match
+        env:
+          CIVICSPARK_API_URL: ${{ secrets.CIVICSPARK_API_URL }}
+          GRANICUS_VIEW_IDS: ${{ vars.GRANICUS_VIEW_IDS || '4' }}
+        run: |
+          if [ -z "$CIVICSPARK_API_URL" ]; then
+            echo "::warning::CIVICSPARK_API_URL secret not set - nothing to sync"
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            echo 'has_jobs=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python scripts/discover_granicus_videos.py \
+            --api-url "$CIVICSPARK_API_URL" \
+            --view-ids "$GRANICUS_VIEW_IDS" \
+            --max-jobs 2 \
+            --output matrix.json
+          echo "matrix=$(cat matrix.json)" >> "$GITHUB_OUTPUT"
+          if [ "$(python -c 'import json;print(len(json.load(open("matrix.json"))["include"]))')" != "0" ]; then
+            echo 'has_jobs=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'has_jobs=false' >> "$GITHUB_OUTPUT"
+          fi
+
+  process:
+    name: "Transcribe + enrich: ${{ matrix.title }}"
+    needs: discover
+    if: needs.discover.outputs.has_jobs == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 320
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q ffmpeg
+
+      - name: Install dependencies
+        run: pip install --quiet faster-whisper requests openai
+
+      - name: Transcribe
+        run: |
+          python scripts/transcribe_meeting.py \
+            --video-url "${{ matrix.video_url }}" \
+            --meeting-id "${{ matrix.meeting_id }}" \
+            --model base.en \
+            --output "transcript-meeting-${{ matrix.meeting_id }}.json"
+
+      - name: Translate, analyze, and upload
+        env:
+          LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+        run: |
+          python scripts/enrich_transcript.py \
+            --transcript "transcript-meeting-${{ matrix.meeting_id }}.json" \
+            --meeting-id "${{ matrix.meeting_id }}" \
+            --languages es \
+            --api-url "${{ secrets.CIVICSPARK_API_URL }}" \
+            --api-token "${{ secrets.TRANSCRIPT_INGEST_TOKEN }}"
+
+      - name: Upload transcript artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: transcript-meeting-${{ matrix.meeting_id }}
+          path: transcript-meeting-${{ matrix.meeting_id }}.json
+          retention-days: 90

--- a/backend/alembic/versions/013_add_translations_and_comments.py
+++ b/backend/alembic/versions/013_add_translations_and_comments.py
@@ -1,0 +1,73 @@
+"""Add transcript translations and meeting comments
+
+Translations ride on transcript segments as a language-keyed JSON map;
+meeting comments give residents a moderated voice on each meeting,
+optionally anchored to a moment in the video.
+
+Revision ID: 013
+Revises: 012
+Create Date: 2026-07-19 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision = "013"
+down_revision = "012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        conn.execute(
+            text(
+                "ALTER TABLE transcript_segments "
+                "ADD COLUMN IF NOT EXISTS translations JSON"
+            )
+        )
+    else:
+        op.add_column(
+            "transcript_segments", sa.Column("translations", sa.JSON(), nullable=True)
+        )
+
+    op.create_table(
+        "meeting_comments",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "meeting_id",
+            sa.Integer(),
+            sa.ForeignKey("meetings.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "user_id", sa.Integer(), sa.ForeignKey("users.id"), nullable=False
+        ),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("display_name", sa.String(200)),
+        sa.Column("video_timestamp", sa.Float(), nullable=True),
+        sa.Column(
+            "is_hidden", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("hidden_reason", sa.String(500)),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now()
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("meeting_comments")
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        conn.execute(
+            text("ALTER TABLE transcript_segments DROP COLUMN IF EXISTS translations")
+        )
+    else:
+        op.drop_column("transcript_segments", "translations")

--- a/backend/app/api/v1/endpoints/meetings.py
+++ b/backend/app/api/v1/endpoints/meetings.py
@@ -3,16 +3,19 @@ import logging
 import re
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import hmac
 
 import httpx
 from app.core.config import Settings, get_settings
 from app.core.database import get_db
+from app.models.comment import MeetingComment
 from app.models.document import DocumentChunk
 from app.models.meeting import AgendaItem, Meeting, MeetingCategory
 from app.models.transcript import TranscriptSegment
+from app.models.user import User
+from app.services.auth import get_current_active_user, get_current_admin_user
 from app.schemas.base import PaginationParams, StandardListResponse
 from app.schemas.meeting import (
     AgendaItemResponse,
@@ -26,7 +29,7 @@ from app.services.ai_categorization_service import AICategorization
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import Text, cast
 from sqlalchemy.orm import Session
 
@@ -322,6 +325,7 @@ class TranscriptSegmentIn(BaseModel):
     start: float
     end: float
     text: str
+    translations: Optional[Dict[str, str]] = None
 
 
 class TranscriptUpload(BaseModel):
@@ -378,6 +382,7 @@ async def upload_transcript(
                 start_seconds=segment.start,
                 end_seconds=segment.end,
                 text=segment.text.strip(),
+                translations=segment.translations or {},
                 source_model=payload.source_model,
             )
         )
@@ -397,6 +402,9 @@ async def upload_transcript(
 async def get_transcript(
     meeting_id: int,
     q: Optional[str] = Query(None, description="Filter segments by text"),
+    lang: Optional[str] = Query(
+        None, description="Preferred language, e.g. 'es' (falls back to original)"
+    ),
     limit: int = Query(500, ge=1, le=2000),
     db: Session = Depends(get_db),
 ):
@@ -420,22 +428,224 @@ async def get_transcript(
         # also accept an explicit start position.
         return f"{meeting.video_url}#t={int(start)}"
 
+    languages = sorted(
+        {
+            code
+            for segment in segments
+            for code in (segment.translations or {}).keys()
+        }
+    )
+
     return {
         "meeting_id": meeting_id,
         "video_url": meeting.video_url,
         "segment_count": len(segments),
         "source_model": segments[0].source_model if segments else None,
+        "languages": languages,
         "segments": [
             {
                 "index": segment.segment_index,
                 "start": segment.start_seconds,
                 "end": segment.end_seconds,
                 "text": segment.text,
+                "translated": (
+                    (segment.translations or {}).get(lang) if lang else None
+                ),
                 "video_link": video_link(segment.start_seconds),
             }
             for segment in segments
         ],
     }
+
+
+class MeetingAnalysis(BaseModel):
+    """Transcript-derived analysis, produced by the media pipeline"""
+
+    summary: Optional[str] = None
+    detailed_summary: Optional[str] = None
+    topics: List[str] = []
+    keywords: List[str] = []
+
+
+@router.post("/{meeting_id}/analysis")
+async def upload_analysis(
+    meeting_id: int,
+    payload: MeetingAnalysis,
+    x_ingest_token: Optional[str] = Header(None),
+    db: Session = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    """Store transcript-derived analysis into the platform's categories.
+
+    Machine ingest (same token as transcripts). Topics/keywords merge
+    into the meeting's existing sets — the same taxonomy that drives
+    browse filters and watch subscriptions — and summaries only fill
+    empty fields, never overwrite human- or minutes-derived content.
+    """
+    _require_ingest_token(settings, x_ingest_token)
+
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+    if not meeting:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    if payload.topics:
+        known = {
+            name.lower(): name
+            for (name,) in db.query(MeetingCategory.name).all()
+        }
+        merged = list(meeting.topics or [])
+        for topic in payload.topics:
+            canonical = known.get(topic.strip().lower())
+            if canonical and canonical not in merged:
+                merged.append(canonical)
+        meeting.topics = merged
+
+    if payload.keywords:
+        merged_keywords = list(meeting.keywords or [])
+        for keyword in payload.keywords:
+            cleaned = keyword.strip()
+            if cleaned and cleaned not in merged_keywords:
+                merged_keywords.append(cleaned)
+        meeting.keywords = merged_keywords[:50]
+
+    if payload.summary and not meeting.summary:
+        meeting.summary = payload.summary
+    if payload.detailed_summary and not meeting.detailed_summary:
+        meeting.detailed_summary = payload.detailed_summary
+
+    db.commit()
+    return {
+        "message": "Analysis stored",
+        "meeting_id": meeting_id,
+        "topics": meeting.topics,
+    }
+
+
+@router.get("/media/pending")
+async def list_pending_media(
+    days: int = Query(30, ge=1, le=365),
+    limit: int = Query(10, ge=1, le=50),
+    db: Session = Depends(get_db),
+):
+    """Recent meetings that have no transcript yet.
+
+    The daily media-sync workflow reads this list, matches it against
+    the Granicus video feed by date, and transcribes what's missing.
+    """
+    since = datetime.utcnow() - timedelta(days=days)
+    transcribed = db.query(TranscriptSegment.meeting_id).distinct().subquery()
+    meetings = (
+        db.query(Meeting)
+        .filter(
+            Meeting.meeting_date >= since,
+            ~Meeting.id.in_(transcribed.select()),
+        )
+        .order_by(Meeting.meeting_date.desc())
+        .limit(limit)
+        .all()
+    )
+    return {
+        "pending": [
+            {
+                "meeting_id": meeting.id,
+                "title": meeting.title,
+                "meeting_date": meeting.meeting_date,
+                "meeting_type": meeting.meeting_type,
+                "external_id": meeting.external_id,
+                "video_url": meeting.video_url,
+            }
+            for meeting in meetings
+        ]
+    }
+
+
+class CommentCreate(BaseModel):
+    content: str = Field(min_length=1, max_length=4000)
+    video_timestamp: Optional[float] = Field(None, ge=0)
+
+
+class CommentHide(BaseModel):
+    reason: Optional[str] = Field(None, max_length=500)
+
+
+@router.get("/{meeting_id}/comments")
+async def list_comments(
+    meeting_id: int,
+    limit: int = Query(100, ge=1, le=500),
+    db: Session = Depends(get_db),
+):
+    """Visible comments on a meeting, oldest first"""
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+    if not meeting:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    comments = (
+        db.query(MeetingComment)
+        .filter(
+            MeetingComment.meeting_id == meeting_id,
+            MeetingComment.is_hidden.is_(False),
+        )
+        .order_by(MeetingComment.created_at)
+        .limit(limit)
+        .all()
+    )
+    return {
+        "comments": [
+            {
+                "id": comment.id,
+                "display_name": comment.display_name or "Resident",
+                "content": comment.content,
+                "video_timestamp": comment.video_timestamp,
+                "created_at": comment.created_at,
+            }
+            for comment in comments
+        ],
+        "total": len(comments),
+    }
+
+
+@router.post("/{meeting_id}/comments")
+async def create_comment(
+    meeting_id: int,
+    payload: CommentCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_active_user),
+):
+    """Post a comment (authenticated residents only; never anonymous spam)"""
+    meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+    if not meeting:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    comment = MeetingComment(
+        meeting_id=meeting_id,
+        user_id=current_user.id,
+        display_name=current_user.full_name or current_user.username,
+        content=payload.content.strip(),
+        video_timestamp=payload.video_timestamp,
+    )
+    db.add(comment)
+    db.commit()
+    return {"message": "Comment posted", "id": comment.id}
+
+
+@router.post("/comments/{comment_id}/hide")
+async def hide_comment(
+    comment_id: int,
+    payload: CommentHide,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_admin_user),
+):
+    """Hide a comment (moderation; hidden, not deleted)"""
+    comment = (
+        db.query(MeetingComment).filter(MeetingComment.id == comment_id).first()
+    )
+    if not comment:
+        raise HTTPException(status_code=404, detail="Comment not found")
+
+    comment.is_hidden = True
+    comment.hidden_reason = payload.reason
+    db.commit()
+    return {"message": "Comment hidden", "id": comment_id}
 
 
 @router.get("/{meeting_id}/pdf")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from .campaign import (
     CampaignUpdate,
     Representative,
 )
+from .comment import MeetingComment
 from .document import (
     Document,
     DocumentChunk,
@@ -32,6 +33,7 @@ __all__ = [
     "Matter",
     "MatterAppearance",
     "TranscriptSegment",
+    "MeetingComment",
     "Document",
     "DocumentChunk",
     "DocumentCollection",

--- a/backend/app/models/comment.py
+++ b/backend/app/models/comment.py
@@ -1,0 +1,48 @@
+from app.core.database import Base
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+
+class MeetingComment(Base):
+    """A resident's comment on a meeting (optionally anchored to a moment).
+
+    Comments come from authenticated users and can be hidden by
+    moderators — hidden, not deleted, so the moderation trail survives.
+    video_timestamp lets a comment point at the exact moment in the
+    recording it responds to.
+    """
+
+    __tablename__ = "meeting_comments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    meeting_id = Column(
+        Integer, ForeignKey("meetings.id"), nullable=False, index=True
+    )
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+
+    content = Column(Text, nullable=False)
+    display_name = Column(String(200))  # captured at post time
+    video_timestamp = Column(Float, nullable=True)  # seconds into the video
+
+    # Moderation
+    is_hidden = Column(Boolean, default=False, nullable=False, index=True)
+    hidden_reason = Column(String(500))
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    meeting = relationship("Meeting")
+    user = relationship("User")
+
+    def __repr__(self):
+        return f"<MeetingComment(meeting={self.meeting_id}, user={self.user_id})>"

--- a/backend/app/models/transcript.py
+++ b/backend/app/models/transcript.py
@@ -1,5 +1,6 @@
 from app.core.database import Base
 from sqlalchemy import (
+    JSON,
     Column,
     DateTime,
     Float,
@@ -37,6 +38,10 @@ class TranscriptSegment(Base):
     # Optional link to the agenda item under discussion (future: aligned
     # via item timestamps when the source publishes them).
     agenda_item_id = Column(Integer, ForeignKey("agenda_items.id"), nullable=True)
+
+    # Translations keyed by language code, e.g. {"es": "..."} — produced
+    # by the enrichment step of the media pipeline.
+    translations = Column(JSON, default=dict)
 
     # Provenance: which model produced this segment.
     source_model = Column(String(100))  # e.g. "faster-whisper/base.en"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,8 +149,24 @@ corpus (the pgvector column is sized from config on fresh databases).
   CPU; a ~3h meeting fits well inside the 6h job limit at $0). Timestamped
   segments land in `transcript_segments` via a shared-secret machine-ingest
   endpoint (`POST /meetings/{id}/transcript`, `TRANSCRIPT_INGEST_TOKEN`),
-  and `GET /meetings/{id}/transcript?q=` returns every quote with a
+  and `GET /meetings/{id}/transcript?q=&lang=` returns every quote with a
   `video_link` pointing at its exact moment in the recording.
+- **Daily media sync** (`.github/workflows/daily-media-sync.yml`): every
+  morning, `discover_granicus_videos.py` reads the Tulsa Granicus (TGOV)
+  RSS feeds, pairs new videos with `/meetings/media/pending` by meeting
+  date, and fans out transcription jobs. `enrich_transcript.py` then
+  translates segments to Spanish and produces an LLM analysis
+  (summary + topics constrained to the platform's category taxonomy),
+  stored via `POST /meetings/{id}/analysis` — topics/keywords merge into
+  the same sets that drive browse filters and watch subscriptions;
+  summaries only fill empty fields. All on free runners with the free
+  Groq tier.
+- **Media UI** (`MeetingMediaPanel`): in the meeting explorer — video
+  player synced two-way with the transcript (click a line to seek,
+  playback highlights and follows the spoken line), English/Español
+  toggle, in-transcript search, and moderated resident comments
+  (authenticated posting, optional anchor to the current video moment,
+  admin hide-with-reason).
 - **Deliberately out (for now)**: councilor stance summaries — per the
   design sketch those ship only with evidence spans and confidence labels,
   never as unlabeled fact.

--- a/frontend/src/components/MeetingMediaPanel.tsx
+++ b/frontend/src/components/MeetingMediaPanel.tsx
@@ -1,0 +1,313 @@
+import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { apiRequest } from '../config/api';
+import { useAuth } from '../contexts/AuthContext';
+import toast from 'react-hot-toast';
+
+/**
+ * Video + transcript + translation + comments panel for a meeting.
+ *
+ * - The video and transcript are synced both ways: clicking a segment
+ *   seeks the video; playback highlights and scrolls to the segment
+ *   being spoken.
+ * - Language toggle shows Spanish (or any available) translations
+ *   produced by the media pipeline.
+ * - Comments are posted by signed-in residents and can be anchored to
+ *   the current video moment.
+ */
+
+interface TranscriptSegment {
+  index: number;
+  start: number;
+  end: number;
+  text: string;
+  translated: string | null;
+  video_link: string | null;
+}
+
+interface TranscriptResponse {
+  meeting_id: number;
+  video_url: string | null;
+  segment_count: number;
+  languages: string[];
+  segments: TranscriptSegment[];
+}
+
+interface MeetingCommentItem {
+  id: number;
+  display_name: string;
+  content: string;
+  video_timestamp: number | null;
+  created_at: string;
+}
+
+const LANGUAGE_LABELS: Record<string, string> = { es: 'Español' };
+
+const formatTime = (seconds: number): string => {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  const mm = h > 0 ? String(m).padStart(2, '0') : String(m);
+  return `${h > 0 ? `${h}:` : ''}${mm}:${String(s).padStart(2, '0')}`;
+};
+
+export const MeetingMediaPanel: React.FC<{ meetingId: number }> = ({ meetingId }) => {
+  const { user } = useAuth();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const activeRef = useRef<HTMLButtonElement>(null);
+
+  const [transcript, setTranscript] = useState<TranscriptResponse | null>(null);
+  const [language, setLanguage] = useState<string>('original');
+  const [search, setSearch] = useState('');
+  const [currentTime, setCurrentTime] = useState(0);
+  const [followPlayback, setFollowPlayback] = useState(true);
+
+  const [comments, setComments] = useState<MeetingCommentItem[]>([]);
+  const [newComment, setNewComment] = useState('');
+  const [anchorToVideo, setAnchorToVideo] = useState(false);
+  const [posting, setPosting] = useState(false);
+
+  useEffect(() => {
+    setTranscript(null);
+    setLanguage('original');
+    setSearch('');
+    const load = async () => {
+      try {
+        const lang = 'es'; // request translations up front; toggle is client-side
+        const data = await apiRequest<TranscriptResponse>(
+          `/api/v1/meetings/${meetingId}/transcript?lang=${lang}`
+        );
+        setTranscript(data);
+      } catch {
+        setTranscript(null); // no transcript yet — panel stays hidden
+      }
+      try {
+        const data = await apiRequest<{ comments: MeetingCommentItem[] }>(
+          `/api/v1/meetings/${meetingId}/comments`
+        );
+        setComments(data.comments);
+      } catch {
+        setComments([]);
+      }
+    };
+    load();
+  }, [meetingId]);
+
+  const filteredSegments = useMemo(() => {
+    if (!transcript) return [];
+    if (!search.trim()) return transcript.segments;
+    const needle = search.toLowerCase();
+    return transcript.segments.filter(
+      (segment) =>
+        segment.text.toLowerCase().includes(needle) ||
+        (segment.translated || '').toLowerCase().includes(needle)
+    );
+  }, [transcript, search]);
+
+  const activeIndex = useMemo(() => {
+    if (!transcript) return -1;
+    return transcript.segments.findIndex(
+      (segment) => currentTime >= segment.start && currentTime < segment.end
+    );
+  }, [transcript, currentTime]);
+
+  useEffect(() => {
+    if (followPlayback && activeRef.current) {
+      activeRef.current.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [activeIndex, followPlayback]);
+
+  const seekTo = useCallback((seconds: number) => {
+    if (videoRef.current) {
+      videoRef.current.currentTime = seconds;
+      videoRef.current.play().catch(() => undefined);
+    }
+  }, []);
+
+  const postComment = async () => {
+    if (!newComment.trim()) return;
+    setPosting(true);
+    try {
+      await apiRequest(`/api/v1/meetings/${meetingId}/comments`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${localStorage.getItem('token')}` },
+        body: JSON.stringify({
+          content: newComment.trim(),
+          video_timestamp:
+            anchorToVideo && videoRef.current ? videoRef.current.currentTime : null,
+        }),
+      });
+      setNewComment('');
+      const data = await apiRequest<{ comments: MeetingCommentItem[] }>(
+        `/api/v1/meetings/${meetingId}/comments`
+      );
+      setComments(data.comments);
+      toast.success('Comment posted');
+    } catch {
+      toast.error('Could not post comment');
+    } finally {
+      setPosting(false);
+    }
+  };
+
+  const hasMedia = transcript && (transcript.video_url || transcript.segment_count > 0);
+  if (!hasMedia && comments.length === 0 && !user) return null;
+
+  return (
+    <div className="p-6 border-b border-gray-200">
+      <h3 className="text-lg font-medium text-gray-900 mb-4">
+        🎬 Meeting Video &amp; Transcript
+      </h3>
+
+      {transcript?.video_url && (
+        <video
+          ref={videoRef}
+          controls
+          preload="metadata"
+          className="w-full rounded-lg mb-4 bg-black"
+          src={transcript.video_url}
+          onTimeUpdate={(e) => setCurrentTime(e.currentTarget.currentTime)}
+        />
+      )}
+
+      {transcript && transcript.segment_count > 0 && (
+        <>
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search the transcript…"
+              className="flex-1 min-w-[180px] border border-gray-300 rounded-md px-3 py-1.5 text-sm"
+            />
+            {transcript.languages.length > 0 && (
+              <div className="flex rounded-md border border-gray-300 overflow-hidden text-sm">
+                <button
+                  className={`px-3 py-1.5 ${language === 'original' ? 'bg-blue-600 text-white' : 'bg-white text-gray-700'}`}
+                  onClick={() => setLanguage('original')}
+                >
+                  English
+                </button>
+                {transcript.languages.map((code) => (
+                  <button
+                    key={code}
+                    className={`px-3 py-1.5 ${language === code ? 'bg-blue-600 text-white' : 'bg-white text-gray-700'}`}
+                    onClick={() => setLanguage(code)}
+                  >
+                    {LANGUAGE_LABELS[code] || code.toUpperCase()}
+                  </button>
+                ))}
+              </div>
+            )}
+            <label className="flex items-center gap-1 text-xs text-gray-600">
+              <input
+                type="checkbox"
+                checked={followPlayback}
+                onChange={(e) => setFollowPlayback(e.target.checked)}
+              />
+              Follow playback
+            </label>
+          </div>
+
+          <div className="max-h-72 overflow-y-auto border border-gray-200 rounded-lg divide-y divide-gray-100">
+            {filteredSegments.map((segment) => {
+              const isActive = segment.index === activeIndex;
+              const display =
+                language !== 'original' && segment.translated
+                  ? segment.translated
+                  : segment.text;
+              return (
+                <button
+                  key={segment.index}
+                  ref={isActive ? activeRef : undefined}
+                  onClick={() => seekTo(segment.start)}
+                  className={`w-full text-left px-3 py-2 text-sm flex gap-3 hover:bg-blue-50 ${
+                    isActive ? 'bg-blue-100' : 'bg-white'
+                  }`}
+                >
+                  <span className="text-blue-600 font-mono text-xs whitespace-nowrap pt-0.5">
+                    {formatTime(segment.start)}
+                  </span>
+                  <span className="text-gray-800">{display}</span>
+                </button>
+              );
+            })}
+            {filteredSegments.length === 0 && (
+              <div className="px-3 py-4 text-sm text-gray-500">
+                No transcript lines match "{search}".
+              </div>
+            )}
+          </div>
+          <div className="mt-1 text-xs text-gray-400">
+            Automated transcript — may contain errors. Click a line to jump the
+            video to that moment.
+          </div>
+        </>
+      )}
+
+      {/* Comments */}
+      <div className="mt-6">
+        <h4 className="text-md font-medium text-gray-900 mb-3">
+          💬 Resident Comments ({comments.length})
+        </h4>
+        <div className="space-y-3 mb-4">
+          {comments.map((comment) => (
+            <div key={comment.id} className="bg-gray-50 rounded-lg p-3">
+              <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+                <span className="font-medium text-gray-700">{comment.display_name}</span>
+                <span>
+                  {comment.video_timestamp !== null && (
+                    <button
+                      className="text-blue-600 hover:underline mr-2"
+                      onClick={() => seekTo(comment.video_timestamp as number)}
+                    >
+                      ▶ {formatTime(comment.video_timestamp)}
+                    </button>
+                  )}
+                  {new Date(comment.created_at).toLocaleDateString()}
+                </span>
+              </div>
+              <div className="text-sm text-gray-800">{comment.content}</div>
+            </div>
+          ))}
+          {comments.length === 0 && (
+            <div className="text-sm text-gray-500">No comments yet.</div>
+          )}
+        </div>
+
+        {user ? (
+          <div>
+            <textarea
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              rows={2}
+              placeholder="Share your perspective on this meeting…"
+              className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm"
+            />
+            <div className="flex items-center justify-between mt-2">
+              <label className="flex items-center gap-1 text-xs text-gray-600">
+                <input
+                  type="checkbox"
+                  checked={anchorToVideo}
+                  onChange={(e) => setAnchorToVideo(e.target.checked)}
+                  disabled={!transcript?.video_url}
+                />
+                Link to current video moment
+              </label>
+              <button
+                onClick={postComment}
+                disabled={posting || !newComment.trim()}
+                className="bg-blue-600 text-white text-sm px-4 py-1.5 rounded-md disabled:opacity-50"
+              >
+                {posting ? 'Posting…' : 'Post comment'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="text-sm text-gray-500">
+            Sign in to join the conversation.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/MeetingsPage.tsx
+++ b/frontend/src/pages/MeetingsPage.tsx
@@ -8,6 +8,7 @@ import { getEnvironmentConfig, getDevModeDisplayText, getApiRetryButtonText, get
 import { PageHeader } from '@/components/PageHeader';
 
 import { ImageCarousel } from '../components/ImageCarousel';
+import { MeetingMediaPanel } from '../components/MeetingMediaPanel';
 import { PDFViewer } from '../components/PDFViewer';
 import { createOpenInNewTabHandler } from '../utils/pdfUtils';
 
@@ -854,6 +855,9 @@ export const MeetingsPage: React.FC = () => {
               </div>
 
               <div className="max-h-[600px] overflow-y-auto">
+                {/* Video, transcript, translations, and resident comments */}
+                <MeetingMediaPanel meetingId={selectedMeeting.id} />
+
                 {/* Meeting Summary */}
                 {selectedMeeting.summary && (
                   <div className="p-6 border-b border-gray-200">

--- a/scripts/discover_granicus_videos.py
+++ b/scripts/discover_granicus_videos.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Discover new Granicus (TGOV) meeting videos and pair them with
+CivicSpark meetings that still lack a transcript.
+
+Tulsa publishes council video through Granicus at tulsa-ok.granicus.com.
+Granicus exposes an RSS/podcast feed per view with direct media
+enclosures:
+
+  {base}/ViewPublisherRSS.php?view_id={id}&mode=vpodcast
+
+This adapter reads those feeds, matches items to the API's
+/meetings/media/pending list by meeting date (same calendar day), and
+emits a JSON matrix for the workflow's transcription jobs.
+
+Usage:
+  python scripts/discover_granicus_videos.py \
+      --api-url https://civicspark-api.onrender.com \
+      [--granicus-base https://tulsa-ok.granicus.com] \
+      [--view-ids 4,7] \
+      [--max-jobs 2] \
+      --output matrix.json
+"""
+
+import argparse
+import json
+import sys
+import xml.etree.ElementTree as ET  # nosec B405 - parsing trusted city feed
+from datetime import datetime
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import requests
+
+
+def fetch_feed_items(granicus_base: str, view_id: str) -> list:
+    """RSS items for one Granicus view: [{title, date, video_url}]"""
+    url = f"{granicus_base.rstrip('/')}/ViewPublisherRSS.php"
+    response = requests.get(
+        url, params={"view_id": view_id, "mode": "vpodcast"}, timeout=60
+    )
+    response.raise_for_status()
+
+    items = []
+    root = ET.fromstring(response.content)  # nosec B314 - city-published feed
+    for item in root.iter("item"):
+        title = (item.findtext("title") or "").strip()
+        enclosure = item.find("enclosure")
+        video_url = enclosure.get("url") if enclosure is not None else None
+        pub_date = None
+        raw_date = item.findtext("pubDate")
+        if raw_date:
+            try:
+                pub_date = parsedate_to_datetime(raw_date)
+            except (TypeError, ValueError):
+                pass
+        if video_url:
+            items.append({"title": title, "date": pub_date, "video_url": video_url})
+    return items
+
+
+def fetch_pending_meetings(api_url: str) -> list:
+    response = requests.get(
+        f"{api_url.rstrip('/')}/api/v1/meetings/media/pending",
+        params={"days": 30, "limit": 25},
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()["pending"]
+
+
+def match(videos: list, pending: list) -> list:
+    """Pair feed videos to pending meetings by calendar day.
+
+    A meeting that already carries a video_url keeps it (re-discovery
+    after a failed transcription run); otherwise the feed item published
+    on the meeting's date wins.
+    """
+    jobs = []
+    used_videos = set()
+
+    for meeting in pending:
+        if meeting.get("video_url"):
+            jobs.append(
+                {
+                    "meeting_id": meeting["meeting_id"],
+                    "video_url": meeting["video_url"],
+                    "title": meeting["title"],
+                }
+            )
+            continue
+
+        meeting_day = (meeting.get("meeting_date") or "")[:10]
+        if not meeting_day:
+            continue
+        for video in videos:
+            if video["video_url"] in used_videos or video["date"] is None:
+                continue
+            if video["date"].strftime("%Y-%m-%d") == meeting_day:
+                used_videos.add(video["video_url"])
+                jobs.append(
+                    {
+                        "meeting_id": meeting["meeting_id"],
+                        "video_url": video["video_url"],
+                        "title": meeting["title"],
+                    }
+                )
+                break
+    return jobs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-url", required=True)
+    parser.add_argument(
+        "--granicus-base", default="https://tulsa-ok.granicus.com"
+    )
+    parser.add_argument(
+        "--view-ids",
+        default="4",
+        help="Comma-separated Granicus view ids (4 = Tulsa council archive)",
+    )
+    parser.add_argument("--max-jobs", type=int, default=2)
+    parser.add_argument("--output", default="matrix.json")
+    args = parser.parse_args()
+
+    videos = []
+    for view_id in [v.strip() for v in args.view_ids.split(",") if v.strip()]:
+        try:
+            found = fetch_feed_items(args.granicus_base, view_id)
+            print(f"View {view_id}: {len(found)} feed items", file=sys.stderr)
+            videos.extend(found)
+        except Exception as e:  # noqa: BLE001 - one bad view must not stop others
+            print(f"View {view_id} failed: {e}", file=sys.stderr)
+
+    pending = fetch_pending_meetings(args.api_url)
+    print(f"{len(pending)} meetings pending transcripts", file=sys.stderr)
+
+    jobs = match(videos, pending)[: args.max_jobs]
+    Path(args.output).write_text(json.dumps({"include": jobs}))
+    print(
+        f"Matched {len(jobs)} job(s): "
+        + ", ".join(f"meeting {j['meeting_id']}" for j in jobs),
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enrich_transcript.py
+++ b/scripts/enrich_transcript.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Enrich a transcript: translate to Spanish and analyze into platform
+categories — using the same free OpenAI-compatible LLM the platform runs
+on (Llama on Groq by default).
+
+Runs in the media-sync workflow after transcription:
+
+  python scripts/enrich_transcript.py \
+      --transcript transcript.json \
+      --meeting-id 42 \
+      [--languages es] \
+      [--api-url https://civicspark-api.onrender.com \
+       --api-token $TRANSCRIPT_INGEST_TOKEN]
+
+Environment: LLM_API_KEY (+ optional LLM_BASE_URL, LLM_MODEL) for
+translation/analysis. Without an LLM key the script uploads the plain
+transcript unchanged, so transcription never blocks on enrichment.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+DEFAULT_BASE_URL = "https://api.groq.com/openai/v1"
+DEFAULT_MODEL = "llama-3.3-70b-versatile"
+TRANSLATE_BATCH = 25
+LANGUAGE_NAMES = {"es": "Spanish"}
+
+
+def get_llm_client():
+    """OpenAI-compatible client from env, or None when unconfigured"""
+    api_key = os.environ.get("LLM_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        return None, None
+    from openai import OpenAI
+
+    base_url = os.environ.get("LLM_BASE_URL", DEFAULT_BASE_URL)
+    model = os.environ.get("LLM_MODEL", DEFAULT_MODEL)
+    if os.environ.get("OPENAI_API_KEY") and not os.environ.get("LLM_API_KEY"):
+        base_url = "https://api.openai.com/v1"
+        model = os.environ.get("LLM_MODEL", "gpt-4.1-mini")
+    return OpenAI(api_key=api_key, base_url=base_url), model
+
+
+def _chat_json(client, model, system: str, user: str):
+    """One JSON-mode chat call; returns parsed JSON or None"""
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            temperature=0.0,
+            max_tokens=4000,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        )
+        return json.loads(response.choices[0].message.content)
+    except Exception as e:  # noqa: BLE001 - enrichment is best-effort
+        print(f"LLM call failed: {e}", file=sys.stderr)
+        return None
+
+
+def translate_segments(client, model, segments: list, language: str) -> int:
+    """Add translations[language] to segments in place; returns count"""
+    language_name = LANGUAGE_NAMES.get(language, language)
+    translated = 0
+    for offset in range(0, len(segments), TRANSLATE_BATCH):
+        batch = segments[offset : offset + TRANSLATE_BATCH]
+        numbered = "\n".join(
+            f"{i}: {segment['text']}" for i, segment in enumerate(batch)
+        )
+        result = _chat_json(
+            client,
+            model,
+            (
+                f"You translate city-council meeting transcript lines into "
+                f"{language_name}. Translate each numbered line faithfully - "
+                "no summarizing, no additions. Return JSON: "
+                '{"translations": {"0": "...", "1": "..."}}'
+            ),
+            numbered,
+        )
+        if not result:
+            continue
+        mapping = result.get("translations", {})
+        for i, segment in enumerate(batch):
+            text = mapping.get(str(i))
+            if text:
+                segment.setdefault("translations", {})[language] = text.strip()
+                translated += 1
+        print(
+            f"Translated {min(offset + TRANSLATE_BATCH, len(segments))}"
+            f"/{len(segments)} segments to {language}",
+            file=sys.stderr,
+        )
+    return translated
+
+
+def fetch_categories(api_url: str) -> list:
+    """Platform topic taxonomy, so analysis lands in known categories"""
+    try:
+        import requests
+
+        response = requests.get(
+            f"{api_url.rstrip('/')}/api/v1/meetings/categories/", timeout=30
+        )
+        response.raise_for_status()
+        return [category["name"] for category in response.json()]
+    except Exception as e:  # noqa: BLE001
+        print(f"Could not fetch categories: {e}", file=sys.stderr)
+        return []
+
+
+def analyze_transcript(client, model, segments: list, categories: list):
+    """Summary + platform-category classification from the transcript"""
+    # Sample the transcript to stay inside context: beginning, middle, end.
+    text = " ".join(segment["text"] for segment in segments)
+    if len(text) > 24000:
+        third = 8000
+        text = f"{text[:third]}\n[...]\n{text[len(text) // 2 - third // 2 : len(text) // 2 + third // 2]}\n[...]\n{text[-third:]}"
+
+    category_list = ", ".join(categories) if categories else "(none provided)"
+    return _chat_json(
+        client,
+        model,
+        (
+            "You analyze city-council meeting transcripts for a civic "
+            "transparency platform. Only state what the transcript "
+            "supports; do not invent votes or figures. Return JSON: "
+            '{"summary": "2-3 sentences", '
+            '"detailed_summary": "one paragraph", '
+            '"topics": ["only names from the allowed list"], '
+            '"keywords": ["5-10 short phrases"]}'
+        ),
+        f"Allowed topic categories: {category_list}\n\nTranscript:\n{text}",
+    )
+
+
+def upload(api_url: str, api_token: str, path: str, meeting_id: int, body: dict):
+    import requests
+
+    response = requests.post(
+        f"{api_url.rstrip('/')}/api/v1/meetings/{meeting_id}/{path}",
+        json=body,
+        headers={"X-Ingest-Token": api_token},
+        timeout=120,
+    )
+    response.raise_for_status()
+    print(f"Uploaded {path}: {response.json()}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--transcript", required=True, help="transcript JSON path")
+    parser.add_argument("--meeting-id", required=True, type=int)
+    parser.add_argument("--languages", default="es", help="comma-separated codes")
+    parser.add_argument("--api-url", default=None)
+    parser.add_argument("--api-token", default=None)
+    args = parser.parse_args()
+
+    payload = json.loads(Path(args.transcript).read_text())
+    segments = payload["segments"]
+
+    client, model = get_llm_client()
+    analysis = None
+    if client is None:
+        print("No LLM configured; skipping translation/analysis.", file=sys.stderr)
+    else:
+        for language in [c.strip() for c in args.languages.split(",") if c.strip()]:
+            count = translate_segments(client, model, segments, language)
+            print(f"{language}: {count} segments translated", file=sys.stderr)
+
+        categories = fetch_categories(args.api_url) if args.api_url else []
+        analysis = analyze_transcript(client, model, segments, categories)
+        if analysis:
+            print(
+                f"Analysis: topics={analysis.get('topics')}",
+                file=sys.stderr,
+            )
+
+    Path(args.transcript).write_text(json.dumps(payload, indent=2))
+
+    if args.api_url and args.api_token:
+        upload(args.api_url, args.api_token, "transcript", args.meeting_id, payload)
+        if analysis:
+            upload(
+                args.api_url,
+                args.api_token,
+                "analysis",
+                args.meeting_id,
+                {
+                    "summary": analysis.get("summary"),
+                    "detailed_summary": analysis.get("detailed_summary"),
+                    "topics": analysis.get("topics") or [],
+                    "keywords": analysis.get("keywords") or [],
+                },
+            )
+    else:
+        print("API upload skipped (no --api-url/--api-token).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/backend/test_media_platform.py
+++ b/tests/backend/test_media_platform.py
@@ -1,0 +1,193 @@
+"""Tests for the media platform: translations, analysis-to-categories,
+pending-media discovery, and moderated comments."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+backend_path = Path(__file__).parent.parent.parent / "backend"
+sys.path.insert(0, str(backend_path))
+
+from app.core.config import Settings, get_settings  # noqa: E402
+from app.core.database import Base, get_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.models.meeting import Meeting, MeetingCategory  # noqa: E402
+from app.models.user import User  # noqa: E402
+from app.services.auth import (  # noqa: E402
+    get_current_active_user,
+    get_current_admin_user,
+)
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+INGEST_TOKEN = "test-ingest-token-not-secret"  # nosec B105
+
+
+@pytest.fixture
+def session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    db = sessionmaker(bind=engine)()
+
+    db.add(
+        Meeting(
+            id=1,
+            title="Regular Council Meeting",
+            meeting_type="city_council",
+            meeting_date=datetime.utcnow(),
+            source="test",
+            topics=["transportation"],
+            keywords=["existing"],
+        )
+    )
+    db.add(MeetingCategory(name="housing", description="Housing"))
+    db.add(MeetingCategory(name="public_safety", description="Public safety"))
+    db.commit()
+    yield db
+    db.close()
+
+
+@pytest.fixture
+def client(session):
+    def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_settings] = lambda: Settings(
+        transcript_ingest_token=INGEST_TOKEN
+    )
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def signed_in(session, client):
+    user = User(
+        id=7,
+        email="resident@example.com",
+        username="resident",
+        full_name="A Resident",
+        hashed_password="x",
+        is_active=True,
+    )
+    session.add(user)
+    session.commit()
+    app.dependency_overrides[get_current_active_user] = lambda: user
+    app.dependency_overrides[get_current_admin_user] = lambda: user
+    return user
+
+
+def test_transcript_translations_round_trip(client):
+    upload = client.post(
+        "/api/v1/meetings/1/transcript",
+        headers={"X-Ingest-Token": INGEST_TOKEN},
+        json={
+            "video_url": "https://granicus.example/v/1.mp4",
+            "segments": [
+                {
+                    "start": 0,
+                    "end": 5,
+                    "text": "The meeting will come to order.",
+                    "translations": {"es": "La reunión comenzará."},
+                }
+            ],
+        },
+    )
+    assert upload.status_code == 200
+
+    data = client.get("/api/v1/meetings/1/transcript?lang=es").json()
+    assert data["languages"] == ["es"]
+    assert data["segments"][0]["translated"] == "La reunión comenzará."
+    assert data["segments"][0]["text"] == "The meeting will come to order."
+
+
+def test_analysis_merges_into_platform_categories(client):
+    response = client.post(
+        "/api/v1/meetings/1/analysis",
+        headers={"X-Ingest-Token": INGEST_TOKEN},
+        json={
+            "summary": "Council discussed housing.",
+            "topics": ["Housing", "not_a_real_category"],
+            "keywords": ["affordable housing", "existing"],
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    # Known category merged (canonical casing), unknown dropped,
+    # existing topics preserved.
+    assert body["topics"] == ["transportation", "housing"]
+
+    meeting = client.get("/api/v1/meetings/1").json()["meeting"]
+    assert meeting["summary"] == "Council discussed housing."
+    assert "affordable housing" in meeting["keywords"]
+    assert meeting["keywords"].count("existing") == 1
+
+
+def test_analysis_never_overwrites_existing_summary(client):
+    client.post(
+        "/api/v1/meetings/1/analysis",
+        headers={"X-Ingest-Token": INGEST_TOKEN},
+        json={"summary": "First summary."},
+    )
+    client.post(
+        "/api/v1/meetings/1/analysis",
+        headers={"X-Ingest-Token": INGEST_TOKEN},
+        json={"summary": "Second summary should not replace."},
+    )
+    meeting = client.get("/api/v1/meetings/1").json()["meeting"]
+    assert meeting["summary"] == "First summary."
+
+
+def test_analysis_requires_token(client):
+    assert (
+        client.post("/api/v1/meetings/1/analysis", json={"summary": "x"}).status_code
+        == 403
+    )
+
+
+def test_pending_media_lists_untranscribed_meetings(client):
+    pending = client.get("/api/v1/meetings/media/pending").json()["pending"]
+    assert [m["meeting_id"] for m in pending] == [1]
+
+    client.post(
+        "/api/v1/meetings/1/transcript",
+        headers={"X-Ingest-Token": INGEST_TOKEN},
+        json={"segments": [{"start": 0, "end": 1, "text": "hello"}]},
+    )
+    pending = client.get("/api/v1/meetings/media/pending").json()["pending"]
+    assert pending == []
+
+
+def test_comments_require_auth_to_post(client):
+    response = client.post(
+        "/api/v1/meetings/1/comments", json={"content": "Great meeting"}
+    )
+    assert response.status_code == 401
+
+
+def test_comment_lifecycle(client, signed_in):
+    posted = client.post(
+        "/api/v1/meetings/1/comments",
+        json={"content": "The curfew discussion starts here.", "video_timestamp": 62.5},
+    )
+    assert posted.status_code == 200
+    comment_id = posted.json()["id"]
+
+    listed = client.get("/api/v1/meetings/1/comments").json()
+    assert listed["total"] == 1
+    assert listed["comments"][0]["display_name"] == "A Resident"
+    assert listed["comments"][0]["video_timestamp"] == 62.5
+
+    hidden = client.post(
+        f"/api/v1/meetings/comments/{comment_id}/hide", json={"reason": "spam"}
+    )
+    assert hidden.status_code == 200
+    assert client.get("/api/v1/meetings/1/comments").json()["total"] == 0


### PR DESCRIPTION
Turns the transcript foundation into a full media layer — daily automated ingest, Spanish translations, analysis into the platform's category taxonomy, and a watch/read/discuss UI. Everything runs on free GitHub runners and the free Groq tier.

## Changes

- **Daily Granicus pull** (`daily-media-sync.yml`): every morning, `discover_granicus_videos.py` reads the Tulsa Granicus (TGOV) RSS feeds, pairs new videos with `GET /meetings/media/pending` by meeting date, and fans out transcription jobs (bounded to 2 meetings/day)
- **Translations**: `enrich_transcript.py` translates segments to Spanish in batches via the platform's OpenAI-compatible LLM provider; stored per-segment (migration 013) and served via `?lang=es` with per-segment fallback
- **Analysis into platform categories**: the enrichment step produces a transcript summary + topic classification constrained to the existing `MeetingCategory` taxonomy; `POST /meetings/{id}/analysis` (ingest token) merges topics/keywords into the same fields that drive browse filters and watch subscriptions, and never overwrites existing summaries
- **Media UI** (`MeetingMediaPanel`): video synced two-way with the transcript (click-to-seek, playback highlight + follow), English/Español toggle, in-transcript search, automated-transcript disclaimer
- **Resident comments**: authenticated posting with optional anchor to the current video moment (anchored comments replay from their timestamp); moderation hides with a recorded reason rather than deleting

## Setup

Repo secrets `CIVICSPARK_API_URL` + `TRANSCRIPT_INGEST_TOKEN` (matching the Render env var), optional `LLM_API_KEY` for translation/analysis, optional `GRANICUS_VIEW_IDS` variable (default `4`). The first live run of the discover job is the real smoke test of Tulsa's feed shape.

## Verification

88 backend tests pass (7 new: translation round-trip, category-constrained analysis merge, summary-overwrite protection, pending-media discovery, comment auth + lifecycle + moderation). Frontend type-checks and builds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V9UtM2rvNnE1bCJR94JUKV)_